### PR TITLE
Prevent the construction of invalid associations

### DIFF
--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -25,6 +25,11 @@ module Restforce
             lookups[mapping.lookup_column] = lookup_id
 
             instance = mapping.salesforce_record_type.find(lookup_id)
+
+            # If any of the mappings are invalid, short-circuit the creation of
+            # the associated record.
+            return [] unless instance
+
             instances << instance
 
             hash.merge(mapping.convert(mapping.database_model, instance.attributes))

--- a/lib/restforce/db/associations/has_one.rb
+++ b/lib/restforce/db/associations/has_one.rb
@@ -21,7 +21,7 @@ module Restforce
           query = "#{lookup_field(target, database_record)} = '#{salesforce_record.Id}'"
 
           instance = target.salesforce_record_type.first(query)
-          construct_for(database_record, instance)
+          instance ? construct_for(database_record, instance) : []
         end
 
       end

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -1,0 +1,195 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:25:30 GMT
+      Set-Cookie:
+      - BrowserId=CXWuPSH8QvCYOFUGY4K_-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:25:30 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557930126","token_type":"Bearer","instance_url":"https://<host>","signature":"r67C8yGA3MlpIHibA9/5ixX6k3b4vIgUwX+3d1iC3Qs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:25:30 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":null}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:25:31 GMT
+      Set-Cookie:
+      - BrowserId=m-mQLSZGT5ywhOztVhoACA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:25:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=13/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001MG7WAAW","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:25:31 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MG7WAAW%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:25:31 GMT
+      Set-Cookie:
+      - BrowserId=7lkL7l8_SNuY-kCjNc0jFA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:25:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=13/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW"},"Id":"a001a000001MG7WAAW","SystemModstamp":"2015-04-20T19:25:31.000+0000","Name":"a001a000001MG7W","Example_Field__c":null,"Friend__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:25:32 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%27%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:25:33 GMT
+      Set-Cookie:
+      - BrowserId=AoKaatypTjaBpGNgJAH23A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:25:33 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=13/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:25:33 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:25:34 GMT
+      Set-Cookie:
+      - BrowserId=GkhRvxVRRTCj8d09-Dp6Kw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:25:34 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=13/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:25:34 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -1,0 +1,196 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:17:58 GMT
+      Set-Cookie:
+      - BrowserId=knvFN9iJTMKYpcGnHxGrNQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:17:58 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557478143","token_type":"Bearer","instance_url":"https://<host>","signature":"ra/+CwNB4ZgXs5e+MFICh3OTNXzz5U4pVS+WeaUDLAU=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:17:58 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Sample object"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:17:59 GMT
+      Set-Cookie:
+      - BrowserId=JaVblvyiRQqfJcGVtSmJ4Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:17:59 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001MFzDAAW","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:17:59 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MFzDAAW%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:18:00 GMT
+      Set-Cookie:
+      - BrowserId=0Ab5uTlGTL-VOz6fZeGBQQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:18:00 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW"},"Id":"a001a000001MFzDAAW","SystemModstamp":"2015-04-20T19:17:59.000+0000","Name":"Sample
+        object","Example_Field__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:18:00 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001MFzDAAW%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:18:01 GMT
+      Set-Cookie:
+      - BrowserId=UZsTVUtDRXy4NAO7ErcPVQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:18:01 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:18:01 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:18:02 GMT
+      Set-Cookie:
+      - BrowserId=t4MT5NpQS2Cm_VnlJC0gag;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:18:02 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:18:02 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -1,0 +1,195 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:15:45 GMT
+      Set-Cookie:
+      - BrowserId=fyl77n8ITN2XO6RXSYfNwQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:15:45 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557345288","token_type":"Bearer","instance_url":"https://<host>","signature":"KWVtlhIqzN6OZ3uEXDa7ZakPVzRL4UeHWNXC7QKJacs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:15:45 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:15:46 GMT
+      Set-Cookie:
+      - BrowserId=ouOxeCEtQlygBOZMsZkTqQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:15:46 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a000002bvGPAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:15:46 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002bvGPAAY%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:15:47 GMT
+      Set-Cookie:
+      - BrowserId=L-qnfxHxQT-0giWwEiWxLQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:15:47 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY"},"Id":"0031a000002bvGPAAY","SystemModstamp":"2015-04-20T19:15:46.000+0000","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:15:47 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002bvGPAAY%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:15:48 GMT
+      Set-Cookie:
+      - BrowserId=T1KkYnY3SHmnBUDVocLZxA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:15:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":0,"done":true,"records":[]}'
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:15:49 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 20 Apr 2015 19:15:49 GMT
+      Set-Cookie:
+      - BrowserId=zs9JsBwzTSuxXfkH1xTs0g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        19-Jun-2015 19:15:49 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 20 Apr 2015 19:15:50 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -69,12 +69,22 @@ describe Restforce::DB::Associations::BelongsTo do
     describe "#build" do
       let(:database_record) { CustomObject.new }
       let(:salesforce_record) { mapping.salesforce_record_type.find(object_salesforce_id).record }
-      let(:associated) { association.build(database_record, salesforce_record).first }
+      let(:associated) { association.build(database_record, salesforce_record) }
 
       it "returns an associated record, populated with the Salesforce attributes" do
-        expect(associated.custom_object).to_equal database_record
-        expect(associated.email).to_equal "somebody@example.com"
-        expect(associated.salesforce_id).to_equal user_salesforce_id
+        record = associated.first
+
+        expect(record.custom_object).to_equal database_record
+        expect(record.email).to_equal "somebody@example.com"
+        expect(record.salesforce_id).to_equal user_salesforce_id
+      end
+
+      describe "when no salesforce record is found for the association" do
+        let(:user_salesforce_id) { nil }
+
+        it "proceeds without constructing any records" do
+          expect(associated).to_be :empty?
+        end
       end
     end
   end

--- a/test/lib/restforce/db/associations/has_many_test.rb
+++ b/test/lib/restforce/db/associations/has_many_test.rb
@@ -91,6 +91,15 @@ describe Restforce::DB::Associations::HasMany do
           expect(record.custom_object).to_equal database_record
         end
       end
+
+      describe "when no salesforce record is found for the association" do
+        let(:detail_salesforce_ids) { nil }
+
+        it "proceeds without constructing any records" do
+          detail_salesforce_ids
+          expect(associated).to_be :empty?
+        end
+      end
     end
   end
 end

--- a/test/lib/restforce/db/associations/has_one_test.rb
+++ b/test/lib/restforce/db/associations/has_one_test.rb
@@ -76,6 +76,14 @@ describe Restforce::DB::Associations::HasOne do
         expect(object.salesforce_id).to_equal object_salesforce_id
       end
 
+      describe "when no salesforce record is found for the association" do
+        let(:object_salesforce_id) { nil }
+
+        it "proceeds without constructing any records" do
+          expect(associated).to_be :empty?
+        end
+      end
+
       describe "and a nested association on the associated mapping" do
         let(:nested_mapping) do
           Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |m|


### PR DESCRIPTION
When an associated record is filtered out (either because it simply
doesn’t exist, or, more likely, because it doesn’t meet the criteria
imposed by the `where` clauses for a specific mapping), we should avoid
attempting to construct the association.

In these cases, it’s up to the developer building out the integration to
ensure that the record can be later synchronized — for example, by using
an `associated` strategy for the mapping which will pick the record up
on later modification.
