### PR TITLE
Clean up change accumulation process

### DIFF
--- a/lib/restforce/db/accumulator.rb
+++ b/lib/restforce/db/accumulator.rb
@@ -8,13 +8,26 @@ module Restforce
     # is then applied to all objects synchronized with that Salesforce object.
     class Accumulator < Hash
 
+      # Public: Store the changeset under the given timestamp. If a changeset
+      # for that timestamp has already been registered, merge it with the newly
+      # passed changeset.
+      #
+      # timestamp - A Time object.
+      # changeset - A Hash mapping attribute names to values.
+      #
+      # Returns nothing.
+      def store(timestamp, changeset)
+        return super unless key?(timestamp)
+        self[timestamp].merge!(changeset)
+      end
+
       # Public: Get the accumulated list of attributes after all changes have
       # been applied.
       #
       # Returns a Hash.
       def attributes
-        sort.reverse.each_with_object({}) do |(_, changeset), final|
-          changeset.each { |attribute, value| final[attribute] ||= value }
+        sort.reverse.inject({}) do |final, (_, changeset)|
+          changeset.merge(final)
         end
       end
 

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -14,6 +14,18 @@ describe Restforce::DB::Accumulator do
     it "stores the passed changeset in the accumulator" do
       expect(accumulator[timestamp]).to_equal changes
     end
+
+    describe "for a pre-existing timestamp" do
+      let(:new_changes) { { old_fish: "New Fish" } }
+
+      before do
+        accumulator.store(timestamp, new_changes)
+      end
+
+      it "updates the existing changeset in the accumulator" do
+        expect(accumulator[timestamp]).to_equal changes.merge(new_changes)
+      end
+    end
   end
 
   describe "#attributes" do


### PR DESCRIPTION
Currently, if a Salesforce object type is shared across multiple 
ActiveRecord models, the only changeset which is respected is the one
corresponding to the most recently-registered mapping. This means that
several other mappings may end up with empty diffs, despite relevant 
changes to their data actually having been made in Salesforce.

The solution is to build up a master changeset across all mapping 
entries for the same timestamp.
