### PR TITLE
Properly handle unrelated mappings in `BelongsTo`

### DIFF
--- a/lib/restforce/db/associations/base.rb
+++ b/lib/restforce/db/associations/base.rb
@@ -61,10 +61,13 @@ module Restforce
         # mapping         - A Restforce::DB::Mapping.
         # database_record - An instance of an ActiveRecord::Base subclass.
         #
-        # Returns a String.
+        # Returns a String or nil.
         def lookup_field(mapping, database_record)
           inverse = inverse_association_name(target_reflection(database_record))
-          mapping.associations.detect { |a| a.name == inverse }.lookup
+          association = mapping.associations.detect { |a| a.name == inverse }
+          return unless association
+
+          association.lookup
         end
 
         # Internal: Get the class of the inverse ActiveRecord association.

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_a_mapping_for_the_target_association_s_class_does_not_have_a_corresponding_association/proceeds_without_raising_an_error.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_a_mapping_for_the_target_association_s_class_does_not_have_a_corresponding_association/proceeds_without_raising_an_error.yml
@@ -1,0 +1,271 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:37 GMT
+      Set-Cookie:
+      - BrowserId=pJidk7gYQ3GCVEMb1Z-p0g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:37 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429758817565","token_type":"Bearer","instance_url":"https://<host>","signature":"ETRbdU1qbtTF4bZuRhnk3OFfLRmxZRMXihMo3PgUaCc=","access_token":"00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH"}'
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:37 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:38 GMT
+      Set-Cookie:
+      - BrowserId=5Nut_wCxQuKIC63Zx74A7A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:38 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a000002eu2wAAA","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:39 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a000002eu2wAAA"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:40 GMT
+      Set-Cookie:
+      - BrowserId=GQLMiMKEQ42kgZCYY5_Guw;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:40 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001QkMJAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:40 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QkMJAA0%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:41 GMT
+      Set-Cookie:
+      - BrowserId=XUQn0DWrTke9Ylns2VGOoQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0"},"Id":"a001a000001QkMJAA0","SystemModstamp":"2015-04-23T03:13:40.000+0000","Name":"a001a000001QkMJ","Example_Field__c":null,"Friend__c":"0031a000002eu2wAAA"}]}'
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:41 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002eu2wAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:42 GMT
+      Set-Cookie:
+      - BrowserId=3Vfxi4vKSCqE0GyreWo3XA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:42 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA"},"Id":"0031a000002eu2wAAA","SystemModstamp":"2015-04-23T03:13:38.000+0000","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:42 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:43 GMT
+      Set-Cookie:
+      - BrowserId=8tDMUoSmSIqzGT4fCP8feg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:43 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=1/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:43 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 23 Apr 2015 03:13:44 GMT
+      Set-Cookie:
+      - BrowserId=ONVEXduoQtKJxklXKfwf9A;Path=/;Domain=.salesforce.com;Expires=Mon,
+        22-Jun-2015 03:13:44 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=2/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 23 Apr 2015 03:13:44 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -86,6 +86,18 @@ describe Restforce::DB::Associations::BelongsTo do
           expect(associated).to_be :empty?
         end
       end
+
+      describe "when a mapping for the target association's class does not have a corresponding association" do
+        let(:extraneous_mapping) { Restforce::DB::Mapping.new(User, "Account") }
+
+        before do
+          Restforce::DB::Registry << extraneous_mapping
+        end
+
+        it "proceeds without raising an error" do
+          expect(associated).to_not_be :empty?
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently, if _any_ of the mappings for a target association class do 
not define an inverse association, `BelongsTo#build` raises an error, as
it expects to be able to find a matching lookup field for _all_ of the
target mappings.

This isn’t necessary; we should be able to populate existing records
from a single corresponding mapping, even if other mappings are defined
which do not correlate to the record currently under construction.
