### PR TITLE
Add rake task to seed entire record categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,21 @@ In the above example, `Dish__c` is a Salesforce object type which references the
 __NOTE__: Unlike `has_one` associations, `has_many` associations do not currently support multiple lookups from the same model. The Lookup is assumed
 to always refer to the `Id` of the parent object.
 
+### Seed your data
+
+To populate your database with existing information from Salesforce (or vice-versa), you _could_ manually update each of the records you care about, and expect the Restforce::DB daemon to automatically pick them up when it runs. However, for any record type you need/want to _fully_ synchronize, this can be a very tedious process. 
+
+In these cases, you can run the `seed` rake task to synchronize the initial records between both systems.
+
+    $ bundle exec rake restforce:seed[<model>,<start_time>,<end_time>,<config>]
+
+The task takes several arguments, most of which are optional:
+
+- `model`: The name of the ActiveRecord model you wish to sync. This can be any model you've defined a mapping for in your application.
+- `start_time` (optional): The earliest point in time for which records should be gathered.
+- `end_time` (optional): The latest point in time for which records should be gathered.
+- `config` (optional): The path to the file containing your Restforce::DB credentials. If not explicitly provided, the default installation file path (see above) will be used.
+
 ### Run the daemon
 
 To actually perform this system synchronization, you'll want to run the binstub installed through the generator (see above). This will daemonize a process which loops repeatedly to continuously synchronize your database and your Salesforce account, according to the established mappings.

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -39,6 +39,8 @@ require "restforce/db/synchronizer"
 require "restforce/db/tracker"
 require "restforce/db/worker"
 
+require "restforce/db/railtie" if defined?(Rails)
+
 module Restforce
 
   # Restforce::DB exposes basic Restforce client configuration methods for use

--- a/lib/restforce/db/railtie.rb
+++ b/lib/restforce/db/railtie.rb
@@ -1,0 +1,19 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Railtie makes Restforce::DB's rake tasks available to any
+    # Rails application which requires the gem.
+    class Railtie < Rails::Railtie
+
+      railtie_name :"restforce-db"
+
+      rake_tasks do
+        load "tasks/restforce.rake"
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -7,7 +7,8 @@ module Restforce
     # modified records within the context of a specific Mapping.
     class Runner
 
-      attr_reader :last_run, :before, :after
+      attr_reader :last_run
+      attr_accessor :before, :after
 
       # Public: Initialize a new Restforce::DB::Runner.
       #

--- a/lib/tasks/restforce.rake
+++ b/lib/tasks/restforce.rake
@@ -1,0 +1,20 @@
+namespace :restforce do
+  desc "Populate all records for a specific model within the specified timespan"
+  task :seed, [:model, :start_time, :end_time, :config] => :environment do |_, args|
+    raise ArgumentError, "the name of an ActiveRecord model must be supplied" unless args[:model]
+
+    config_file = args[:config] || Rails.root.join("config", "restforce-db.yml")
+    Restforce::DB.configure { |config| config.parse(config_file) }
+
+    runner = Restforce::DB::Runner.new
+    runner.after = Time.parse(args[:start_time]) if args[:start_time].present?
+    runner.before = Time.parse(args[:end_time]) if args[:end_time].present?
+
+    target_class = args[:model].constantize
+    Restforce::DB::Registry[target_class].each do |mapping|
+      puts "SYNCHRONIZING between #{mapping.database_model.name} and #{mapping.salesforce_model}"
+      Restforce::DB::Initializer.new(mapping, runner).run
+      puts "DONE"
+    end
+  end
+end


### PR DESCRIPTION
Once Restforce::DB is up and running with a given mapping, it will stay
up to date over the course of each synchronization. However, when 
setting up an initial mapping, it’s often desirable to synchronize all
existing information.

Currently, this requires manually updating the individual Salesforce
records to force a sync. To obviate the need for such a tedious manual 
process, we’re adding a “seed” Rake task to perform this initial record
population.