### PR TITLE
Remove newly-invalidated records from synchronization

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -31,6 +31,7 @@ require "restforce/db/runner"
 
 require "restforce/db/accumulator"
 require "restforce/db/attribute_map"
+require "restforce/db/cleaner"
 require "restforce/db/collector"
 require "restforce/db/initializer"
 require "restforce/db/mapping"

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -42,8 +42,8 @@ module Restforce
       def all_salesforce_ids
         all_ids = []
 
-        @mapping.unscoped do |m|
-          @runner.run(m) do |run|
+        @mapping.unscoped do |map|
+          @runner.run(map) do |run|
             run.salesforce_records { |record| all_ids << record.id }
           end
         end

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -1,0 +1,72 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Cleaner is responsible for culling the matching database
+    # records when a Salesforce record no longer meets the sync conditions.
+    class Cleaner
+
+      # Public: Initialize a Restforce::DB::Cleaner.
+      #
+      # mapping - A Restforce::DB::Mapping.
+      # runner  - A Restforce::DB::Runner.
+      def initialize(mapping, runner = Runner.new)
+        @mapping = mapping
+        @strategy = mapping.strategy
+        @runner = runner
+      end
+
+      # Public: Run the database culling loop for this mapping.
+      #
+      # Returns nothing.
+      def run
+        return if @strategy.passive?
+        @mapping.database_record_type.destroy_all(invalid_salesforce_ids)
+      end
+
+      private
+
+      # Internal: Get the IDs of records which are in the larger collection
+      # of Salesforce records, but which do not meet the specific conditions for
+      # this mapping.
+      #
+      # Returns an Array of IDs.
+      def invalid_salesforce_ids
+        all_salesforce_ids - valid_salesforce_ids
+      end
+
+      # Internal: Get the IDs of all recently-modified Salesforce records
+      # corresponding to the object type for this mapping.
+      #
+      # Returns an Array of IDs.
+      def all_salesforce_ids
+        all_ids = []
+
+        @mapping.unscoped do |m|
+          @runner.run(m) do |run|
+            run.salesforce_records { |record| all_ids << record.id }
+          end
+        end
+
+        all_ids
+      end
+
+      # Internal: Get the IDs of the recently-modified Salesforce records which
+      # meet the conditions for this mapping.
+      #
+      # Returns an Array of IDs.
+      def valid_salesforce_ids
+        valid_ids = []
+
+        @runner.run(@mapping) do |run|
+          run.salesforce_records { |record| valid_ids << record.id }
+        end
+
+        valid_ids
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/mapping.rb
+++ b/lib/restforce/db/mapping.rb
@@ -87,6 +87,22 @@ module Restforce
         end
       end
 
+      # Public: Access the Mapping object without any conditions on the fetched
+      # records. Allows for a comparison of all modified records to only those
+      # modified records that still fit the `where` criteria.
+      #
+      # block - A block of code to execute in a condition-less context.
+      #
+      # Yields the Mapping with its conditions removed.
+      # Returns the result of the block.
+      def unscoped
+        criteria = @conditions
+        @conditions = []
+        yield self
+      ensure
+        @conditions = criteria
+      end
+
       private
 
       # Internal: Get an AttributeMap for the fields defined for this mapping.

--- a/lib/restforce/db/record_types/active_record.rb
+++ b/lib/restforce/db/record_types/active_record.rb
@@ -66,6 +66,16 @@ module Restforce
           end
         end
 
+        # Public: Destroy all database records corresponding to the list of
+        # passed Salesforce IDs.
+        #
+        # ids - An Array of Salesforce IDs.
+        #
+        # Returns nothing.
+        def destroy_all(ids)
+          @record_type.where(@mapping.lookup_column => ids).destroy_all
+        end
+
         # Public: Does the model represented by this record type have a column
         # with the requested name?
         #

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -128,6 +128,7 @@ module Restforce
       # Returns nothing.
       def propagate(mapping)
         Initializer.new(mapping, runner).run
+        Cleaner.new(mapping, runner).run
       end
 
       # Internal: Collect a list of changes from recently-updated records for

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -77,6 +77,7 @@ module Restforce
 
           Restforce::DB::Registry.each do |mapping|
             task("PROPAGATING RECORDS", mapping) { propagate mapping }
+            task("CLEANING RECORDS", mapping) { clean mapping }
             task("COLLECTING CHANGES", mapping) { collect mapping }
           end
 
@@ -128,6 +129,15 @@ module Restforce
       # Returns nothing.
       def propagate(mapping)
         Initializer.new(mapping, runner).run
+      end
+
+      # Internal: Remove synchronized records from the database when the
+      # Salesforce record no longer meets the mapping's conditions.
+      #
+      # mapping - A Restforce::DB::Mapping.
+      #
+      # Returns nothing.
+      def clean(mapping)
         Cleaner.new(mapping, runner).run
       end
 

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/for_a_non-Passive_strategy/drops_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/for_a_non-Passive_strategy/drops_the_synchronized_database_record.yml
@@ -1,0 +1,200 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:20 GMT
+      Set-Cookie:
+      - BrowserId=Mv4KGAcATkaQUlaR0LmBiQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:20 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430260520482","token_type":"Bearer","instance_url":"https://<host>","signature":"yQWlkrP+VEy6cJMr8X01tKUcp3jJfdab28DpozcgRRk=","access_token":"00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI"}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:20 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
+        Sage, Rosemary, and Thyme."}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:20 GMT
+      Set-Cookie:
+      - BrowserId=3WUn9_WbQZGC6UHfLFxLmQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:20 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=6/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0KAAS"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001Sr0KAAS","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:20 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:21 GMT
+      Set-Cookie:
+      - BrowserId=z-eXo_idQN6fNmKWqkMjUQ;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:21 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"},{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0KAAS"},"Id":"a001a000001Sr0KAAS","SystemModstamp":"2015-04-28T22:35:20.000+0000","Name":"Are
+        you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
+        and Thyme."}]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:21 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:21 GMT
+      Set-Cookie:
+      - BrowserId=lCyOd81BQGCTyp4OGv1j6A;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:21 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:21 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0KAAS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:22 GMT
+      Set-Cookie:
+      - BrowserId=KOe6M7BRQ0-6dcG-gG0bEg;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:22 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:22 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
@@ -1,0 +1,202 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:14 GMT
+      Set-Cookie:
+      - BrowserId=ATzeC8sYTiON60FmYuKong;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430260514286","token_type":"Bearer","instance_url":"https://<host>","signature":"8KSXxaHQWEXc7N8QF4D7sei0VTdPiA9Acov+SAqtAC0=","access_token":"00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI"}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:14 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
+        Sage, Rosemary, and Thyme."}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:14 GMT
+      Set-Cookie:
+      - BrowserId=7F5nncr9TF661qns_ENlfw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0FAAS"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001Sr0FAAS","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:14 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:14 GMT
+      Set-Cookie:
+      - BrowserId=LPwX--hBSJ2-qXwhmGa1Rw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"},{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0FAAS"},"Id":"a001a000001Sr0FAAS","SystemModstamp":"2015-04-28T22:35:14.000+0000","Name":"Are
+        you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
+        and Thyme."}]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:14 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:14 GMT
+      Set-Cookie:
+      - BrowserId=zLWLapMfQDuUw4XC2ORLBw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"},{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0FAAS"},"Id":"a001a000001Sr0FAAS","SystemModstamp":"2015-04-28T22:35:14.000+0000","Name":"Are
+        you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
+        and Thyme."}]}'
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:14 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001Sr0FAAS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQKiSKdgqc4RvsFXyw8iT6exh89uDmXHSdoOm02DBwGRy9GlP_kVfG5FkxxjC_xd0GhiDTxOOu7j2B3K7FlG1lJo1IecI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 28 Apr 2015 22:35:15 GMT
+      Set-Cookie:
+      - BrowserId=wCjzqpiIQKGLi3e1ZCi2hA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        27-Jun-2015 22:35:15 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 28 Apr 2015 22:35:15 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -20,9 +20,9 @@ describe Restforce::DB::Associations::BelongsTo do
 
   describe "with an inverse mapping", :vcr do
     let(:inverse_mapping) do
-      Restforce::DB::Mapping.new(User, "Contact").tap do |m|
-        m.fields = { email: "Email" }
-        m.associations << Restforce::DB::Associations::HasOne.new(
+      Restforce::DB::Mapping.new(User, "Contact").tap do |map|
+        map.fields = { email: "Email" }
+        map.associations << Restforce::DB::Associations::HasOne.new(
           :custom_object,
           through: "Friend__c",
         )

--- a/test/lib/restforce/db/associations/has_many_test.rb
+++ b/test/lib/restforce/db/associations/has_many_test.rb
@@ -20,9 +20,9 @@ describe Restforce::DB::Associations::HasMany do
 
   describe "with an inverse mapping", :vcr do
     let(:inverse_mapping) do
-      Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |m|
-        m.fields = { name: "Name" }
-        m.associations << Restforce::DB::Associations::BelongsTo.new(
+      Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |map|
+        map.fields = { name: "Name" }
+        map.associations << Restforce::DB::Associations::BelongsTo.new(
           :custom_object,
           through: "CustomObject__c",
         )

--- a/test/lib/restforce/db/associations/has_one_test.rb
+++ b/test/lib/restforce/db/associations/has_one_test.rb
@@ -21,9 +21,9 @@ describe Restforce::DB::Associations::HasOne do
 
   describe "with an inverse mapping", :vcr do
     let(:inverse_mapping) do
-      Restforce::DB::Mapping.new(User, "Contact").tap do |m|
-        m.fields = { email: "Email" }
-        m.associations << association
+      Restforce::DB::Mapping.new(User, "Contact").tap do |map|
+        map.fields = { email: "Email" }
+        map.associations << association
       end
     end
     let(:user_salesforce_id) do
@@ -87,9 +87,9 @@ describe Restforce::DB::Associations::HasOne do
 
       describe "and a nested association on the associated mapping" do
         let(:nested_mapping) do
-          Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |m|
-            m.fields = { name: "Name" }
-            m.associations << Restforce::DB::Associations::BelongsTo.new(
+          Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |map|
+            map.fields = { name: "Name" }
+            map.associations << Restforce::DB::Associations::BelongsTo.new(
               :custom_object,
               through: "CustomObject__c",
             )

--- a/test/lib/restforce/db/attribute_map_test.rb
+++ b/test/lib/restforce/db/attribute_map_test.rb
@@ -17,8 +17,8 @@ describe Restforce::DB::AttributeMap do
 
   describe "#attributes" do
     let(:mapping) do
-      Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |m|
-        m.fields = fields
+      Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |map|
+        map.fields = fields
       end
     end
 

--- a/test/lib/restforce/db/cleaner_test.rb
+++ b/test/lib/restforce/db/cleaner_test.rb
@@ -1,0 +1,56 @@
+require_relative "../../../test_helper"
+
+describe Restforce::DB::Cleaner do
+
+  configure!
+  mappings!
+
+  let(:cleaner) { Restforce::DB::Cleaner.new(mapping) }
+
+  describe "#run", vcr: { match_requests_on: [:method, VCR.request_matchers.uri_without_param(:q)] } do
+    let(:attributes) do
+      {
+        name: "Are you going to Scarborough Fair?",
+        example: "Parsley, Sage, Rosemary, and Thyme.",
+      }
+    end
+    let(:salesforce_id) do
+      Salesforce.create!(
+        salesforce_model,
+        mapping.convert(salesforce_model, attributes),
+      )
+    end
+
+    describe "given a synchronized Salesforce record" do
+      before do
+        database_model.create!(salesforce_id: salesforce_id)
+      end
+
+      describe "when the record meets the mapping conditions" do
+        before do
+          cleaner.run
+        end
+
+        it "does not drop the synchronized database record" do
+          expect(database_model.last).to_not_be_nil
+        end
+      end
+
+      describe "when the record does not meet the mapping conditions" do
+        before do
+          mapping.conditions = ["Name != '#{attributes[:name]}'"]
+        end
+
+        describe "for a non-Passive strategy" do
+          before do
+            cleaner.run
+          end
+
+          it "drops the synchronized database record" do
+            expect(database_model.last).to_be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/restforce/db/mapping_test.rb
+++ b/test/lib/restforce/db/mapping_test.rb
@@ -13,8 +13,8 @@ describe Restforce::DB::Mapping do
     }
   end
   let(:mapping) do
-    Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |m|
-      m.fields = fields
+    Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |map|
+      map.fields = fields
     end
   end
 
@@ -96,7 +96,7 @@ describe Restforce::DB::Mapping do
 
     it "removes the conditions from the mapping within the context of the block" do
       expect(mapping.conditions).to_not_be :empty?
-      mapping.unscoped { |m| expect(m.conditions).to_be :empty? }
+      mapping.unscoped { |map| expect(map.conditions).to_be :empty? }
       expect(mapping.conditions).to_not_be :empty?
     end
   end

--- a/test/lib/restforce/db/mapping_test.rb
+++ b/test/lib/restforce/db/mapping_test.rb
@@ -88,4 +88,16 @@ describe Restforce::DB::Mapping do
       end
     end
   end
+
+  describe "#unscoped" do
+    before do
+      mapping.conditions = ["Some_Condition__c = TRUE"]
+    end
+
+    it "removes the conditions from the mapping within the context of the block" do
+      expect(mapping.conditions).to_not_be :empty?
+      mapping.unscoped { |m| expect(m.conditions).to_be :empty? }
+      expect(mapping.conditions).to_not_be :empty?
+    end
+  end
 end

--- a/test/lib/restforce/db/record_types/active_record_test.rb
+++ b/test/lib/restforce/db/record_types/active_record_test.rb
@@ -47,9 +47,9 @@ describe Restforce::DB::RecordTypes::ActiveRecord do
           through: "Friend__c",
         )
 
-        associated_mapping = Restforce::DB::Mapping.new(User, "Contact").tap do |m|
-          m.fields  = { email: "Email" }
-          m.associations << Restforce::DB::Associations::HasOne.new(
+        associated_mapping = Restforce::DB::Mapping.new(User, "Contact").tap do |map|
+          map.fields  = { email: "Email" }
+          map.associations << Restforce::DB::Associations::HasOne.new(
             :custom_object,
             through: "Friend__c",
           )

--- a/test/lib/restforce/db/record_types/active_record_test.rb
+++ b/test/lib/restforce/db/record_types/active_record_test.rb
@@ -92,4 +92,27 @@ describe Restforce::DB::RecordTypes::ActiveRecord do
       expect(record_type.find("a001a000001E1vFAKE")).to_be_nil
     end
   end
+
+  describe "#destroy_all" do
+    before do
+      database_model.create!(salesforce_id: salesforce_id)
+      record_type.destroy_all(ids)
+    end
+
+    describe "when the passed ids include the Salesforce ID of an existing record" do
+      let(:ids) { [salesforce_id] }
+
+      it "eliminates the matching record(s)" do
+        expect(database_model.last).to_be_nil
+      end
+    end
+
+    describe "when the passed ids do not include the Salesforce ID of an existing record" do
+      let(:ids) { ["a001a000001E1vFAKE"] }
+
+      it "does not eliminate the matching record(s)" do
+        expect(database_model.last).to_not_be_nil
+      end
+    end
+  end
 end

--- a/test/lib/restforce/db/strategies/associated_test.rb
+++ b/test/lib/restforce/db/strategies/associated_test.rb
@@ -15,9 +15,9 @@ describe Restforce::DB::Strategies::Associated do
 
     describe "given an inverse mapping" do
       let(:inverse_mapping) do
-        Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |m|
-          m.fields = { name: "Name" }
-          m.associations << Restforce::DB::Associations::BelongsTo.new(
+        Restforce::DB::Mapping.new(Detail, "CustomObjectDetail__c").tap do |map|
+          map.fields = { name: "Name" }
+          map.associations << Restforce::DB::Associations::BelongsTo.new(
             :custom_object,
             through: "CustomObject__c",
           )

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -20,9 +20,9 @@ def mappings!
   let(:fields) { { name: "Name", example: "Example_Field__c" } }
   let(:conditions) { [] }
   let(:mapping) do
-    Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |m|
-      m.conditions = conditions
-      m.fields     = fields
+    Restforce::DB::Mapping.new(database_model, salesforce_model).tap do |map|
+      map.conditions = conditions
+      map.fields     = fields
     end
   end
 end


### PR DESCRIPTION
These changes introduce `Restforce::DB::Cleaner`, an object which coordinates the detection of "invalid" Salesforce records and removal of the corresponding database records from the system.

I've inserted the invocation of the `Cleaner` into the "Propagate" step, since cleaning up records logically fits with the process of record  propagation, but I could be argued into splitting it into its own discretely-logged step.