### PR TITLE
Support multi-way lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,7 @@ This _also_ defines an inverse relationship for a `belongs_to` relationship. The
 
 In the above example, `Dish__c` is a Salesforce object type which references the `Restaurant__c` object type through an aptly-named Lookup. There is no restriction on the number of `Dish__c` objects that may reference the same `Restaurant__c`, so we define this relationship as a `has_many` associaition in our `Restaurant` mapping.
 
-__NOTE__: Unlike `has_one` associations, `has_many` associations do not currently support multiple lookups from the same model. The Lookup is assumed
-to always refer to the `Id` of the parent object.
+__NOTE__: If one side of an association has multiple possible lookup fields, the other side of the association is expected to declare a _single_ lookup field, which will be treated as the canonical lookup for that relationship. The Lookup is assumed to always refer to the `Id` of the object declaring the `has_many`/`has_one` side of the association.
 
 ### Seed your data
 

--- a/lib/restforce/db/associations/base.rb
+++ b/lib/restforce/db/associations/base.rb
@@ -55,6 +55,25 @@ module Restforce
 
         private
 
+        # Internal: Get the appropriate Salesforce Lookup ID field for the
+        # passed mapping.
+        #
+        # mapping         - A Restforce::DB::Mapping.
+        # database_record - An instance of an ActiveRecord::Base subclass.
+        #
+        # Returns a String or nil.
+        def lookup_field(mapping, database_record)
+          inverse = inverse_association_name(target_reflection(database_record))
+          association = mapping.associations.detect { |a| a.name == inverse }
+          return unless association
+
+          if lookup.is_a?(Array)
+            association.lookup
+          else
+            lookup
+          end
+        end
+
         # Internal: Get a list of all newly-constructed records based on this
         # association, for a set of lookups.
         #

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -76,21 +76,6 @@ module Restforce
           salesforce_instance.record[inverse_association.lookup] if salesforce_instance
         end
 
-        # Internal: Get the appropriate Salesforce Lookup ID field for the
-        # passed mapping.
-        #
-        # mapping         - A Restforce::DB::Mapping.
-        # database_record - An instance of an ActiveRecord::Base subclass.
-        #
-        # Returns a String or nil.
-        def lookup_field(mapping, database_record)
-          inverse = inverse_association_name(target_reflection(database_record))
-          association = mapping.associations.detect { |a| a.name == inverse }
-          return unless association
-
-          association.lookup
-        end
-
       end
 
     end

--- a/lib/restforce/db/associations/has_many.rb
+++ b/lib/restforce/db/associations/has_many.rb
@@ -21,7 +21,7 @@ module Restforce
           @cache = cache
 
           target = target_mapping(database_record)
-          lookup_id = "#{lookup} = '#{salesforce_record.Id}'"
+          lookup_id = "#{lookup_field(target, database_record)} = '#{salesforce_record.Id}'"
 
           records = []
           target.salesforce_record_type.each(conditions: lookup_id) do |instance|

--- a/lib/restforce/db/associations/has_one.rb
+++ b/lib/restforce/db/associations/has_one.rb
@@ -21,7 +21,7 @@ module Restforce
           @cache = cache
 
           target = target_mapping(database_record)
-          query = "#{lookup} = '#{salesforce_record.Id}'"
+          query = "#{lookup_field(target, database_record)} = '#{salesforce_record.Id}'"
 
           instance = target.salesforce_record_type.first(query)
           instance ? construct_for(database_record, instance) : []


### PR DESCRIPTION
To provide better support for polymorphic mappings (generally in the
form of STI), we need to allow for `belongs_to` relationships to define
a single lookup which may correspond to a generic `has_many` association
on the target record.