### PR TITLE
Update associated record assignments

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -31,6 +31,7 @@ require "restforce/db/strategies/passive"
 require "restforce/db/runner"
 
 require "restforce/db/accumulator"
+require "restforce/db/associator"
 require "restforce/db/attribute_map"
 require "restforce/db/cleaner"
 require "restforce/db/collector"

--- a/lib/restforce/db/association_cache.rb
+++ b/lib/restforce/db/association_cache.rb
@@ -10,8 +10,11 @@ module Restforce
       attr_reader :cache
 
       # Public: Initialize a new Restforce::DB::AssociationCache.
-      def initialize
+      #
+      # record - An instance of ActiveRecord::Base (optional).
+      def initialize(record = nil)
         @cache = Hash.new { |h, k| h[k] = [] }
+        self << record if record
       end
 
       # Public: Add a record to the cache.

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -45,6 +45,27 @@ module Restforce
           @cache = nil
         end
 
+        # Public: Get a Hash of Lookup IDs for a specified database record,
+        # based on the currently record for this association.
+        #
+        # database_record - An instance of an ActiveRecord::Base subclass.
+        #
+        # Returns a Hash.
+        def lookups(database_record)
+          ids = {}
+
+          for_mappings(database_record) do |mapping, lookup|
+            associated = database_record.association(name).reader
+
+            # It's possible to define a belongs_to association in a Mapping for
+            # what is actually a one-to-many association in ActiveRecord.
+            associated = associated.first if associated.respond_to?(:first)
+            ids[lookup] = associated.send(mapping.lookup_column)
+          end
+
+          ids
+        end
+
         private
 
         # Internal: Iterate through all relevant mappings for the target

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -57,14 +57,13 @@ module Restforce
           for_mappings(database_record) do |mapping, lookup|
             associated = database_record.association(name).reader
 
-            if associated
-              # It's possible to define a belongs_to association in a Mapping
-              # for what is actually a one-to-many association in ActiveRecord.
-              associated = associated.first if associated.respond_to?(:first)
-              ids[lookup] = associated.send(mapping.lookup_column)
-            else
-              ids[lookup] = nil
-            end
+            ids[lookup] =
+              if associated
+                # It's possible to define a belongs_to association in a Mapping
+                # for what is actually a one-to-many association on the
+                # ActiveRecord object.
+                Array(associated).first.send(mapping.lookup_column)
+              end
           end
 
           ids

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -90,7 +90,7 @@ module Restforce
         # Internal: Get the Salesforce ID belonging to the associated record
         # for a supplied instance. Must be implemented per-association.
         #
-        # instance - A Restforce::DB::Instances::Base
+        # instance - A Restforce::DB::Instances::Base.
         #
         # Returns a String.
         def associated_salesforce_id(instance)

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -57,10 +57,14 @@ module Restforce
           for_mappings(database_record) do |mapping, lookup|
             associated = database_record.association(name).reader
 
-            # It's possible to define a belongs_to association in a Mapping for
-            # what is actually a one-to-many association in ActiveRecord.
-            associated = associated.first if associated.respond_to?(:first)
-            ids[lookup] = associated.send(mapping.lookup_column)
+            if associated
+              # It's possible to define a belongs_to association in a Mapping
+              # for what is actually a one-to-many association in ActiveRecord.
+              associated = associated.first if associated.respond_to?(:first)
+              ids[lookup] = associated.send(mapping.lookup_column)
+            else
+              ids[lookup] = nil
+            end
           end
 
           ids

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -46,7 +46,7 @@ module Restforce
         end
 
         # Public: Get a Hash of Lookup IDs for a specified database record,
-        # based on the currently record for this association.
+        # based on the current record for this association.
         #
         # database_record - An instance of an ActiveRecord::Base subclass.
         #

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -14,10 +14,10 @@ module Restforce
         #
         # database_record   - An instance of an ActiveRecord::Base subclass.
         # salesforce_record - A Hashie::Mash representing a Salesforce object.
-        # cache             - A Restforce::DB::AssociationCache.
+        # cache             - A Restforce::DB::AssociationCache (optional).
         #
         # Returns an Array of constructed association records.
-        def build(database_record, salesforce_record, cache = AssociationCache.new)
+        def build(database_record, salesforce_record, cache = AssociationCache.new(database_record))
           @cache = cache
 
           lookups = {}

--- a/lib/restforce/db/associations/has_many.rb
+++ b/lib/restforce/db/associations/has_many.rb
@@ -14,10 +14,10 @@ module Restforce
         #
         # database_record   - An instance of an ActiveRecord::Base subclass.
         # salesforce_record - A Hashie::Mash representing a Salesforce object.
-        # cache             - A Restforce::DB::AssociationCache.
+        # cache             - A Restforce::DB::AssociationCache (optional).
         #
         # Returns an Array of constructed association records.
-        def build(database_record, salesforce_record, cache = AssociationCache.new)
+        def build(database_record, salesforce_record, cache = AssociationCache.new(database_record))
           @cache = cache
 
           target = target_mapping(database_record)

--- a/lib/restforce/db/associations/has_one.rb
+++ b/lib/restforce/db/associations/has_one.rb
@@ -14,10 +14,10 @@ module Restforce
         #
         # database_record   - An instance of an ActiveRecord::Base subclass.
         # salesforce_record - A Hashie::Mash representing a Salesforce object.
-        # cache             - A Restforce::DB::AssociationCache.
+        # cache             - A Restforce::DB::AssociationCache (optional).
         #
         # Returns an Array of constructed association records.
-        def build(database_record, salesforce_record, cache = AssociationCache.new)
+        def build(database_record, salesforce_record, cache = AssociationCache.new(database_record))
           @cache = cache
 
           target = target_mapping(database_record)

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -1,0 +1,104 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Associator is responsible for determining when one or more
+    # associations have been updated to point to a new Salesforce/database
+    # record, and propagate the modification to the opposite system when this
+    # occurs.
+    class Associator
+
+      # Public: Initialize a new Restforce::DB::Associator.
+      #
+      # mapping - A Restforce::DB::Mapping instance.
+      # runner  - A Restforce::DB::Runner instance.
+      def initialize(mapping, runner = Runner.new)
+        @mapping = mapping
+        @runner = runner
+      end
+
+      # Public: Run the re-association process, pulling in records from
+      # Salesforce and the database to determine the most recently attached
+      # association, then propagating the change between systems.
+      #
+      # Returns nothing.
+      def run
+        return if associations.empty?
+
+        @runner.run(@mapping) do |run|
+          run.salesforce_instances { |instance| verify_associations(instance) }
+          run.database_instances { |instance| verify_associations(instance) }
+        end
+      end
+
+      private
+
+      # Internal: Ensure integrity between the lookup columns in Salesforce and
+      # the synchronized records in the database.
+      #
+      # instance - A Restforce::DB::Instances::Base.
+      #
+      # Returns nothing.
+      def verify_associations(instance)
+        database_instance, salesforce_instance =
+          case instance
+          when Restforce::DB::Instances::Salesforce
+            [@mapping.database_record_type.find(instance.id), instance]
+          when Restforce::DB::Instances::ActiveRecord
+            [instance, @mapping.salesforce_record_type.find(instance.id)]
+          end
+
+        return unless database_instance && salesforce_instance
+        sync_associations(database_instance, salesforce_instance)
+      end
+
+      # Internal: Given a database record and corresponding Salesforce data,
+      # synchronize the record associations in whichever system has the least
+      # recent data.
+      #
+      # database_instance   - A Restforce::DB::Instances::ActiveRecord.
+      # salesforce_instance - A Restforce::DB::Instances::Salesforce.
+      #
+      # Returns nothing.
+      def sync_associations(database_instance, salesforce_instance)
+        ids = association_ids(database_instance)
+        return if ids.all? { |field, id| salesforce_instance.record[field] == id }
+
+        if database_instance.last_update > salesforce_instance.last_update
+          salesforce_instance.update!(ids)
+        else
+          database_record = database_instance.record
+          associations.each do |association|
+            association.build(database_record, salesforce_instance.record)
+          end
+          database_record.save!
+        end
+      end
+
+      # Internal: Get a Hash of associated lookup IDs for the passed database
+      # record.
+      #
+      # database_instance - A Restforce::DB::Instances::ActiveRecord.
+      #
+      # Returns a Hash.
+      def association_ids(database_instance)
+        associations.inject({}) do |ids, association|
+          ids.merge(association.lookups(database_instance.record))
+        end
+      end
+
+      # Internal: Get a list of the BelongsTo associations defined for the
+      # target mapping.
+      #
+      # Returns an Array of Restforce::DB::Association::BelongsTo objects.
+      def associations
+        @associations ||= @mapping.associations.select do |association|
+          association.is_a?(Restforce::DB::Associations::BelongsTo)
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -23,7 +23,7 @@ module Restforce
       #
       # Returns nothing.
       def run
-        return if associations.empty?
+        return if belongs_to_associations.empty?
 
         @runner.run(@mapping) do |run|
           run.salesforce_instances { |instance| verify_associations(instance) }
@@ -61,14 +61,14 @@ module Restforce
       #
       # Returns nothing.
       def sync_associations(database_instance, salesforce_instance)
-        ids = association_ids(database_instance)
+        ids = belongs_to_association_ids(database_instance)
         return if ids.all? { |field, id| salesforce_instance.record[field] == id }
 
         if database_instance.last_update > salesforce_instance.last_update
           salesforce_instance.update!(ids)
         else
           database_record = database_instance.record
-          associations.each do |association|
+          belongs_to_associations.each do |association|
             association.build(database_record, salesforce_instance.record)
           end
           database_record.save!
@@ -81,8 +81,8 @@ module Restforce
       # database_instance - A Restforce::DB::Instances::ActiveRecord.
       #
       # Returns a Hash.
-      def association_ids(database_instance)
-        associations.inject({}) do |ids, association|
+      def belongs_to_association_ids(database_instance)
+        belongs_to_associations.inject({}) do |ids, association|
           ids.merge(association.lookups(database_instance.record))
         end
       end
@@ -91,8 +91,8 @@ module Restforce
       # target mapping.
       #
       # Returns an Array of Restforce::DB::Association::BelongsTo objects.
-      def associations
-        @associations ||= @mapping.associations.select do |association|
+      def belongs_to_associations
+        @belongs_to_associations ||= @mapping.associations.select do |association|
           association.is_a?(Restforce::DB::Associations::BelongsTo)
         end
       end

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -44,7 +44,7 @@ module Restforce
 
         @mapping.unscoped do |map|
           @runner.run(map) do |run|
-            run.salesforce_records { |record| all_ids << record.id }
+            run.salesforce_instances { |instance| all_ids << instance.id }
           end
         end
 
@@ -59,7 +59,7 @@ module Restforce
         valid_ids = []
 
         @runner.run(@mapping) do |run|
-          run.salesforce_records { |record| valid_ids << record.id }
+          run.salesforce_instances { |instance| valid_ids << instance.id }
         end
 
         valid_ids

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -20,7 +20,7 @@ module Restforce
       #
       # Returns nothing.
       def run
-        return if @strategy.passive?
+        return if @mapping.conditions.empty? || @strategy.passive?
         @mapping.database_record_type.destroy_all(invalid_salesforce_ids)
       end
 

--- a/lib/restforce/db/collector.rb
+++ b/lib/restforce/db/collector.rb
@@ -30,8 +30,8 @@ module Restforce
         @accumulated_changes = accumulator || accumulated_changes
 
         @runner.run(@mapping) do |run|
-          run.salesforce_records { |record| accumulate(record) }
-          run.database_records { |record| accumulate(record) }
+          run.salesforce_instances { |instance| accumulate(instance) }
+          run.database_instances { |instance| accumulate(instance) }
         end
 
         accumulated_changes

--- a/lib/restforce/db/collector.rb
+++ b/lib/restforce/db/collector.rb
@@ -8,8 +8,6 @@ module Restforce
     # locate recently-updated records and fetch their attributes.
     class Collector
 
-      attr_reader :last_run
-
       # Public: Initialize a new Restforce::DB::Collector.
       #
       # mapping - A Restforce::DB::Mapping instance.

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -25,8 +25,8 @@ module Restforce
         return if @strategy.passive?
 
         @runner.run(@mapping) do |run|
-          run.salesforce_records { |record| create_in_database(record) }
-          run.database_records { |record| create_in_salesforce(record) }
+          run.salesforce_instances { |instance| create_in_database(instance) }
+          run.database_instances { |instance| create_in_salesforce(instance) }
         end
       end
 
@@ -36,24 +36,24 @@ module Restforce
       # passed Salesforce record. Does nothing if the Salesforce record has
       # already been synchronized into the system at least once.
       #
-      # record - A Restforce::DB::Instances::Salesforce.
+      # instance - A Restforce::DB::Instances::Salesforce.
       #
       # Returns nothing.
-      def create_in_database(record)
-        return unless @strategy.build?(record)
-        @mapping.database_record_type.create!(record)
+      def create_in_database(instance)
+        return unless @strategy.build?(instance)
+        @mapping.database_record_type.create!(instance)
       end
 
       # Internal: Attempt to create a partner record in Salesforce for the
       # passed database record. Does nothing if the database record already has
       # an associated Salesforce record.
       #
-      # record - A Restforce::DB::Instances::ActiveRecord.
+      # instance - A Restforce::DB::Instances::ActiveRecord.
       #
       # Returns nothing.
-      def create_in_salesforce(record)
-        return if record.synced?
-        @mapping.salesforce_record_type.create!(record)
+      def create_in_salesforce(instance)
+        return if instance.synced?
+        @mapping.salesforce_record_type.create!(instance)
       end
 
     end

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -52,8 +52,8 @@ module Restforce
       #
       # Yields a series of Restforce::DB::Instances::Salesforce objects.
       # Returns nothing.
-      def salesforce_records
-        @mapping.salesforce_record_type.each(options) { |record| yield record }
+      def salesforce_instances
+        @mapping.salesforce_record_type.each(options) { |instance| yield instance }
       end
 
       # Public: Iterate through recently-updated records for the database model
@@ -61,8 +61,8 @@ module Restforce
       #
       # Yields a series of Restforce::DB::Instances::ActiveRecord objects.
       # Returns nothing.
-      def database_records
-        @mapping.database_record_type.each(options) { |record| yield record }
+      def database_instances
+        @mapping.database_record_type.each(options) { |instance| yield instance }
       end
 
       private

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -82,6 +82,7 @@ module Restforce
             task("PROPAGATING RECORDS", mapping) { propagate mapping }
             task("CLEANING RECORDS", mapping) { clean mapping }
             task("COLLECTING CHANGES", mapping) { collect mapping }
+            task("UPDATING ASSOCIATIONS", mapping) { associate mapping }
           end
 
           # NOTE: We can only perform the synchronization after all record
@@ -152,6 +153,16 @@ module Restforce
       # Returns nothing.
       def collect(mapping)
         Collector.new(mapping, runner).run(@changes)
+      end
+
+      # Internal: Update the associated records and Salesforce lookups for
+      # records belonging to the passed mapping.
+      #
+      # mapping - A Restforce::DB::Mapping.
+      #
+      # Returns nothing.
+      def associate(mapping)
+        Associator.new(mapping, runner).run
       end
 
       # Internal: Apply the aggregated changes to the objects in both systems,

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -37,15 +37,7 @@ module Restforce
       #
       # Returns nothing.
       def start
-        trap("TERM") do
-          Thread.new { log "Exiting..." }
-          stop
-        end
-
-        trap("INT") do
-          Thread.new { log "Exiting..." }
-          stop
-        end
+        trap_signals
 
         loop do
           runtime = Benchmark.realtime { perform }
@@ -60,10 +52,21 @@ module Restforce
       #
       # Returns nothing.
       def stop
+        Thread.new { log "Exiting..." }
         @exit = true
       end
 
       private
+
+      # Internal: Configure the main loop to trap specific signals, triggering
+      # an exit once the loop completes.
+      #
+      # Return nothing.
+      def trap_signals
+        %w(TERM INT).each do |signal|
+          trap(signal) { stop }
+        end
+      end
 
       # Internal: Perform the synchronization loop, recording the time that the
       # run is performed so that future runs can pick up where the last run

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
@@ -1,0 +1,195 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:03:46 GMT
+      Set-Cookie:
+      - BrowserId=xEedI-vySRW2ERl7-YhVMQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:03:46 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430708626705","token_type":"Bearer","instance_url":"https://<host>","signature":"l9dFCE7hnrj+RVNOaga2AVC08CivElFFEXzzLx249cg=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:03:46 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:03:47 GMT
+      Set-Cookie:
+      - BrowserId=JXXP7EFFSGmPNZoB147Iaw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:03:47 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=62/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a00000317qmAAA"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a00000317qmAAA","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:03:47 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a00000317qmAAA"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:03:48 GMT
+      Set-Cookie:
+      - BrowserId=JSTACFWYRfGvSN-pXUImfQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:03:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=62/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16LAAS"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001U16LAAS","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:03:49 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317qmAAA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:03:49 GMT
+      Set-Cookie:
+      - BrowserId=fw6pUrTnSsaUmxeHralylA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:03:49 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=62/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:03:50 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16LAAS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:03:51 GMT
+      Set-Cookie:
+      - BrowserId=dZMbqhy9So-af3I7wNJe7w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:03:51 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=62/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:03:51 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:11:53 GMT
+      Set-Cookie:
+      - BrowserId=xMX1dTw3TIGcKjfx_Cujpw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:11:53 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430709113521","token_type":"Bearer","instance_url":"https://<host>","signature":"2BWFc3pyXdIWgSNtXnE+OpZDdD+Oas7Mk3KKVvtfEzw=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:11:53 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Sample object"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:11:54 GMT
+      Set-Cookie:
+      - BrowserId=5-H8lcRDTYW0wIDWnj21qA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:11:54 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=66/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16VAAS"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001U16VAAS","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:11:54 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16VAAS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:11:55 GMT
+      Set-Cookie:
+      - BrowserId=7IbTrRJmRZCYf_zWQWFUKQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:11:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=66/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:11:55 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_Salesforce_association_is_out_of_date/updates_the_association_ID_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_Salesforce_association_is_out_of_date/updates_the_association_ID_in_Salesforce.yml
@@ -1,0 +1,421 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:02 GMT
+      Set-Cookie:
+      - BrowserId=yvfdr2-lRUWDXnJCSiRQIQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:02 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430709302836","token_type":"Bearer","instance_url":"https://<host>","signature":"sFPalnpID5aebkLrX2Ui9oaUhnVquClzL8oGEP1X84Q=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:03 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:03 GMT
+      Set-Cookie:
+      - BrowserId=5QD_KalWSjurkTsT2UeiqQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:03 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a00000317s9AAA"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a00000317s9AAA","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:04 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a00000317s9AAA"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:05 GMT
+      Set-Cookie:
+      - BrowserId=vsYe3TlKTOqifwbXSOMOsg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:05 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001U16aAAC","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:05 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody+else@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:06 GMT
+      Set-Cookie:
+      - BrowserId=PngGdYPHSNeBUbD-g4IGQA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:06 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a00000317sEAAQ"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a00000317sEAAQ","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:06 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:07 GMT
+      Set-Cookie:
+      - BrowserId=9Vf48MKSRHSK-Vu8pY3kjQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:07 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC"},"Id":"a001a000001U16aAAC","SystemModstamp":"2015-05-04T03:15:05.000+0000","Name":"a001a000001U16a","Example_Field__c":null,"Friend__c":"0031a00000317s9AAA"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:07 GMT
+- request:
+    method: patch
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a00000317sEAAQ"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:08 GMT
+      Set-Cookie:
+      - BrowserId=S15nAXXcQ5qYhBjXEID16w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:08 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=69/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:08 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001U16aAAC%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:09 GMT
+      Set-Cookie:
+      - BrowserId=A-_hzIHkSZqfv6e7WmBuuQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:09 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC"},"Id":"a001a000001U16aAAC","SystemModstamp":"2015-05-04T03:15:08.000+0000","Name":"a001a000001U16a","Example_Field__c":null,"Friend__c":"0031a00000317sEAAQ"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:09 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001U16aAAC%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:10 GMT
+      Set-Cookie:
+      - BrowserId=2-h8hBXZR5esa2Tk7ldn-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:10 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC"},"Id":"a001a000001U16aAAC","SystemModstamp":"2015-05-04T03:15:08.000+0000","Name":"a001a000001U16a","Example_Field__c":null,"Friend__c":"0031a00000317sEAAQ"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:10 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317s9AAA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:11 GMT
+      Set-Cookie:
+      - BrowserId=_GJx2oo7TN-pyeWTJ9bMqQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:11 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=69/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:11 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16aAAC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:12 GMT
+      Set-Cookie:
+      - BrowserId=e1pJVn3hSR6X1HmSBc854g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:12 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:13 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317sEAAQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:14 GMT
+      Set-Cookie:
+      - BrowserId=tqMBYV_TS263SkfMWEqCPg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:14 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:14 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
+++ b/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
@@ -1,0 +1,459 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:20 GMT
+      Set-Cookie:
+      - BrowserId=f8mT0XHDTJiqRCvhSpY_nw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:20 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430709320615","token_type":"Bearer","instance_url":"https://<host>","signature":"8YDUYsEk+RvjVXfzp8kUPZwqF5ZDV+zfzWC0hZdlceo=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:20 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:21 GMT
+      Set-Cookie:
+      - BrowserId=MMuCD0IJRX2swBbsGuPA-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:21 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=70/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a00000317sJAAQ"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a00000317sJAAQ","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:21 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a00000317sJAAQ"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:22 GMT
+      Set-Cookie:
+      - BrowserId=ZnzL6tDeT_SlR_nk4Ea-mg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:22 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Location:
+      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001U16fAAC","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:22 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001U16fAAC%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:23 GMT
+      Set-Cookie:
+      - BrowserId=TDgwznv8TPOZ4mPOR91kcA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:23 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=69/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC"},"Id":"a001a000001U16fAAC","SystemModstamp":"2015-05-04T03:15:22.000+0000","Name":"a001a000001U16f","Example_Field__c":null,"Friend__c":"0031a00000317sJAAQ"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:23 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    body:
+      encoding: UTF-8
+      string: '{"Email":"somebody+else@example.com","LastName":"Somebody"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:24 GMT
+      Set-Cookie:
+      - BrowserId=o_6Udn33SPC9dPTD-nQMiw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Location:
+      - "/services/data/v26.0/sobjects/Contact/0031a00000317sOAAQ"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"0031a00000317sOAAQ","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:24 GMT
+- request:
+    method: patch
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC
+    body:
+      encoding: UTF-8
+      string: '{"Friend__c":"0031a00000317sOAAQ"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:25 GMT
+      Set-Cookie:
+      - BrowserId=P7z15TEeTMOc2R28NJSBwg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:25 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:25 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:26 GMT
+      Set-Cookie:
+      - BrowserId=XZnTGUjXTtajVhsmadKB_Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:26 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=69/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC"},"Id":"a001a000001U16fAAC","SystemModstamp":"2015-05-04T03:15:25.000+0000","Name":"a001a000001U16f","Example_Field__c":null,"Friend__c":"0031a00000317sOAAQ"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:26 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a00000317sOAAQ%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:27 GMT
+      Set-Cookie:
+      - BrowserId=G9XG-lj1SRGOENEjmobfJA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:27 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=69/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a00000317sOAAQ"},"Id":"0031a00000317sOAAQ","SystemModstamp":"2015-05-04T03:15:24.000+0000","Email":"somebody+else@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:27 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001U16fAAC%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:28 GMT
+      Set-Cookie:
+      - BrowserId=IPfzlBlnQba69A4hz7fdaQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:28 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC"},"Id":"a001a000001U16fAAC","SystemModstamp":"2015-05-04T03:15:25.000+0000","Name":"a001a000001U16f","Example_Field__c":null,"Friend__c":"0031a00000317sOAAQ"}]}'
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:28 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317sJAAQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:29 GMT
+      Set-Cookie:
+      - BrowserId=CM7k5n2TQ_CFPUIjTEkx0Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:29 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:29 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16fAAC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:30 GMT
+      Set-Cookie:
+      - BrowserId=dCi5gw0SSlOdFSYPj_9ijA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:30 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=68/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:30 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317sOAAQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 04 May 2015 03:15:31 GMT
+      Set-Cookie:
+      - BrowserId=XU3CDz1IR0-rsD2l9dipSg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        03-Jul-2015 03:15:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=70/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 May 2015 03:15:32 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -1,6 +1,9 @@
 require_relative "../../../test_helper"
 
 describe Restforce::DB::Accumulator do
+
+  configure!
+
   let(:accumulator) { Restforce::DB::Accumulator.new }
 
   describe "#store" do

--- a/test/lib/restforce/db/association_cache_test.rb
+++ b/test/lib/restforce/db/association_cache_test.rb
@@ -9,6 +9,14 @@ describe Restforce::DB::AssociationCache do
   let(:lookups) { { salesforce_id: "a001a000001E1vREAL" } }
   let(:record) { database_model.new(lookups) }
 
+  describe "#initialize" do
+    let(:cache) { Restforce::DB::AssociationCache.new(record) }
+
+    it "caches the passed record when present" do
+      expect(cache.cache[database_model]).to_equal [record]
+    end
+  end
+
   describe "#<<" do
     before do
       cache << record

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -52,6 +52,15 @@ describe Restforce::DB::Associations::BelongsTo do
       it "returns a hash of the associated records' lookup IDs" do
         expect(association.lookups(object)).to_equal("Friend__c" => user_salesforce_id)
       end
+
+      describe "when there is currently no associated record" do
+        let(:object_salesforce_id) { Salesforce.create!(mapping.salesforce_model) }
+        let(:object) { mapping.database_model.create!(salesforce_id: object_salesforce_id) }
+
+        it "returns a nil lookup value in the hash" do
+          expect(association.lookups(object)).to_equal("Friend__c" => nil)
+        end
+      end
     end
 
     describe "#synced_for?" do

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -45,6 +45,15 @@ describe Restforce::DB::Associations::BelongsTo do
       mapping.associations << association
     end
 
+    describe "#lookups" do
+      let(:user) { inverse_mapping.database_model.create!(salesforce_id: user_salesforce_id) }
+      let(:object) { mapping.database_model.create!(salesforce_id: object_salesforce_id, user: user) }
+
+      it "returns a hash of the associated records' lookup IDs" do
+        expect(association.lookups(object)).to_equal("Friend__c" => user_salesforce_id)
+      end
+    end
+
     describe "#synced_for?" do
       let(:salesforce_instance) { mapping.salesforce_record_type.find(object_salesforce_id) }
 

--- a/test/lib/restforce/db/associator_test.rb
+++ b/test/lib/restforce/db/associator_test.rb
@@ -1,0 +1,82 @@
+require_relative "../../../test_helper"
+
+describe Restforce::DB::Associator do
+
+  configure!
+  mappings!
+
+  let(:associator) { Restforce::DB::Associator.new(mapping) }
+
+  describe "#run", :vcr do
+
+    describe "given a BelongsTo association" do
+      let(:inverse_mapping) do
+        Restforce::DB::Mapping.new(User, "Contact").tap do |map|
+          map.fields = { email: "Email" }
+          map.associations << Restforce::DB::Associations::HasOne.new(
+            :custom_object,
+            through: "Friend__c",
+          )
+        end
+      end
+      let(:user_salesforce_id) do
+        Salesforce.create!(
+          inverse_mapping.salesforce_model,
+          "Email" => "somebody@example.com",
+          "LastName" => "Somebody",
+        )
+      end
+      let(:object_salesforce_id) do
+        Salesforce.create!(mapping.salesforce_model, "Friend__c" => user_salesforce_id)
+      end
+      let(:association) { Restforce::DB::Associations::BelongsTo.new(:user, through: "Friend__c") }
+      let(:user) { inverse_mapping.database_model.create!(salesforce_id: user_salesforce_id) }
+      let(:object) { mapping.database_model.create!(user: user, salesforce_id: object_salesforce_id) }
+
+      before do
+        Restforce::DB::Registry << mapping
+        Restforce::DB::Registry << inverse_mapping
+        mapping.associations << association
+      end
+
+      describe "given another record for association" do
+        let(:new_user_salesforce_id) do
+          Salesforce.create!(
+            inverse_mapping.salesforce_model,
+            "Email" => "somebody+else@example.com",
+            "LastName" => "Somebody",
+          )
+        end
+        let(:new_user) { inverse_mapping.database_model.create!(salesforce_id: new_user_salesforce_id) }
+        let(:salesforce_instance) { mapping.salesforce_record_type.find(object_salesforce_id) }
+
+        describe "when the Salesforce association is out of date" do
+          before do
+            object.update!(user: new_user)
+          end
+
+          it "updates the association ID in Salesforce" do
+            associator.run
+            expect(salesforce_instance.record["Friend__c"]).to_equal new_user_salesforce_id
+          end
+        end
+
+        describe "when the database association is out of date" do
+          before do
+            object && new_user
+            salesforce_instance.update! "Friend__c" => new_user_salesforce_id
+          end
+
+          it "updates the associated record in the database" do
+            # We stub `last_update` to get around issues with VCR's cached
+            # timestamp; we need the Salesforce record to be more recent.
+            Restforce::DB::Instances::Salesforce.stub_any_instance(:last_update, Time.now) do
+              associator.run
+            end
+            expect(object.reload.user).to_equal new_user
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/restforce/db/configuration_test.rb
+++ b/test/lib/restforce/db/configuration_test.rb
@@ -1,6 +1,9 @@
 require_relative "../../../test_helper"
 
 describe Restforce::DB::Configuration do
+
+  configure!
+
   let(:secrets) { Secrets["client"] }
   let(:secrets_file) { File.expand_path("../../../../config/secrets.yml", __FILE__) }
   let(:configuration) { Restforce::DB::Configuration.new }

--- a/test/lib/restforce/db/dsl_test.rb
+++ b/test/lib/restforce/db/dsl_test.rb
@@ -2,6 +2,8 @@ require_relative "../../../test_helper"
 
 describe Restforce::DB::DSL do
 
+  configure!
+
   let(:database_model) { CustomObject }
   let(:salesforce_model) { "CustomObject__c" }
   let(:strategy) { :always }

--- a/test/lib/restforce/db/runner_test.rb
+++ b/test/lib/restforce/db/runner_test.rb
@@ -1,6 +1,9 @@
 require_relative "../../../test_helper"
 
 describe Restforce::DB::Runner do
+
+  configure!
+
   let(:runner) { Restforce::DB::Runner.new }
 
   describe "#initialize" do

--- a/test/lib/restforce/db/strategies/passive_test.rb
+++ b/test/lib/restforce/db/strategies/passive_test.rb
@@ -1,6 +1,9 @@
 require_relative "../../../../test_helper"
 
 describe Restforce::DB::Strategies::Passive do
+
+  configure!
+
   let(:strategy) { Restforce::DB::Strategies::Passive.new }
 
   it "is a passive strategy" do

--- a/test/lib/restforce/db/strategy_test.rb
+++ b/test/lib/restforce/db/strategy_test.rb
@@ -2,6 +2,8 @@ require_relative "../../../test_helper"
 
 describe Restforce::DB::Strategy do
 
+  configure!
+
   describe ".for" do
     let(:strategy) { Restforce::DB::Strategy.for(type) }
 

--- a/test/lib/restforce/db/tracker_test.rb
+++ b/test/lib/restforce/db/tracker_test.rb
@@ -1,6 +1,9 @@
 require_relative "../../../test_helper"
 
 describe Restforce::DB::Tracker do
+
+  configure!
+
   let(:file) { Tempfile.new(".restforce-db") }
   let(:tracker) { Restforce::DB::Tracker.new(file.path) }
   let(:runtime) { Time.now }

--- a/test/support/stub.rb
+++ b/test/support/stub.rb
@@ -1,0 +1,37 @@
+# Extend all objects with `#stub_any_instance`. Implementation taken from:
+# https://github.com/codeodor/minitest-stub_any_instance
+class Object
+
+  # Public: Stub the specified method for any instance of the passed class
+  # within the context of a block.
+  #
+  # name            - A String or Symbol method name.
+  # val_or_callable - The value which the stubbed method should return.
+  # block           - A block of code to execute in this context.
+  #
+  # Returns nothing.
+  def self.stub_any_instance(name, val_or_callable)
+    new_name = "__minitest_any_instance_stub__#{name}"
+
+    class_eval do
+      alias_method new_name, name
+
+      define_method(name) do |*args|
+        if val_or_callable.respond_to?(:call)
+          instance_exec(*args, &val_or_callable)
+        else
+          val_or_callable
+        end
+      end
+    end
+
+    yield
+  ensure
+    class_eval do
+      undef_method name
+      alias_method name, new_name
+      undef_method new_name
+    end
+  end
+
+end


### PR DESCRIPTION
When an association is modified in either Salesforce or the database, we
want to ensure that the same modification is applied in the other
system. Thus, when a Lookup is changed in Salesforce, we want to point
our database record to the synchronized record for that association, and
when a database record’s association is modified, we want to update the
Lookup in Salesforce.

To this end, we’ve added an Associator object, which handles the 
responsibility of identifying obsolete association links, and updating
those links in the appropriate systems.