### PR TITLE
Support full-fledged Adapter object conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ class Restaurant < ActiveRecord::Base
 
   module StyleAdapter
 
-    def self.to(attributes)
+    def self.to_database(attributes)
       attributes.each_with_object do |(key, value), final|
         final[k] = value.chomp(" in Salesforce")
       end
     end
 
-    def self.from(attributes)
+    def self.from_database(attributes)
       attributes.each_with_object do |(key, value), final|
         final[k] = "#{value} in Salesforce"
       end
@@ -141,11 +141,11 @@ Your ActiveRecord class _must_ expose readers for each attribute in the mapping,
 
 #### Field Conversions
 
-`converts_with` defines a mapping conversion adapter. The only requirement for an adapter is that it respond to the methods `#to` and `#from`. 
+`converts_with` defines a mapping conversion adapter. The only requirement for an adapter is that it respond to the methods `#to_database` and `#from_database`. 
 
-- `#to` will be handed a "normalized" Hash, with the standard Symbol mapped attributes as keys, and the values as they are stored in Salesforce. It should return a modified version of the Hash which can be passed to `assign_attributes` for a record.
+- `#to_database` will be handed a "normalized" Hash, with the standard Symbol mapped attributes as keys, and the values as they are stored in Salesforce. It should return a modified version of the Hash which can be passed to `assign_attributes` for a record.
 
-- `#from` will be handed a Hash with the standard Symbol mapped attributes as keys, and the values for those attributes as they are returned by the ActiveRecord object. It should return a modified version of the Hash with values suitable for storage in Salesforce.
+- `#from_database` will be handed a Hash with the standard Symbol mapped attributes as keys, and the values for those attributes as they are returned by the ActiveRecord object. It should return a modified version of the Hash with values suitable for storage in Salesforce.
 
 By default, `Restforce::DB::Adapter` will be used, which simply converts times into String ISO-8601 timestamps before passing them off to Salesforce.
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ class Restaurant < ActiveRecord::Base
   module StyleAdapter
 
     def self.to_database(attributes)
-      attributes.each_with_object do |(key, value), final|
-        final[k] = value.chomp(" in Salesforce")
+      attributes.each_with_object({}) do |(key, value), final|
+        final[key] = value.chomp(" in Salesforce")
       end
     end
 
     def self.from_database(attributes)
-      attributes.each_with_object do |(key, value), final|
-        final[k] = "#{value} in Salesforce"
+      attributes.each_with_object({}) do |(key, value), final|
+        final[key] = "#{value} in Salesforce"
       end
     end
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ class Restaurant < ActiveRecord::Base
 
   module StyleAdapter
 
-    def self.to_salesforce(attributes)
+    def self.to(attributes)
       attributes.each_with_object do |(key, value), final|
-        final[k] = "#{value} in Salesforce"
+        final[k] = value.chomp(" in Salesforce")
       end
     end
 
-    def self.to_database(value)
+    def self.from(attributes)
       attributes.each_with_object do |(key, value), final|
-        final[k] = value.chomp(" in Salesforce")
+        final[k] = "#{value} in Salesforce"
       end
     end
 
@@ -137,9 +137,15 @@ Individual conditions supplied to `where` will be appended together with `AND` c
 
 `maps` defines a set of direct field-to-field mappings. It takes a Hash as an argument; the keys should line up with your ActiveRecord attribute names, while the values should line up with the matching field names in Salesforce.
 
+Your ActiveRecord class _must_ expose readers for each attribute in the mapping, and generally _should_ expose matching writers, though you can use an adapter object (see "Field Conversions" below) to obviate the need for the latter.
+
 #### Field Conversions
 
-`converts_with` defines a mapping conversion adapter. The only requirement for an adapter is that it respond to the methods `#to_database` and `#to_salesforce`. These methods will be handed a "normalized" mapping Hash as an argument, and should return a modified version of the Hash with values suited for the relevant system.
+`converts_with` defines a mapping conversion adapter. The only requirement for an adapter is that it respond to the methods `#to` and `#from`. 
+
+- `#to` will be handed a "normalized" Hash, with the standard Symbol mapped attributes as keys, and the values as they are stored in Salesforce. It should return a modified version of the Hash which can be passed to `assign_attributes` for a record.
+
+- `#from` will be handed a Hash with the standard Symbol mapped attributes as keys, and the values for those attributes as they are returned by the ActiveRecord object. It should return a modified version of the Hash with values suitable for storage in Salesforce.
 
 By default, `Restforce::DB::Adapter` will be used, which simply converts times into String ISO-8601 timestamps before passing them off to Salesforce.
 

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -32,6 +32,7 @@ require "restforce/db/runner_cache"
 require "restforce/db/runner"
 
 require "restforce/db/accumulator"
+require "restforce/db/adapter"
 require "restforce/db/associator"
 require "restforce/db/attribute_map"
 require "restforce/db/cleaner"

--- a/lib/restforce/db/accumulator.rb
+++ b/lib/restforce/db/accumulator.rb
@@ -31,6 +31,19 @@ module Restforce
         end
       end
 
+      # Public: Get a Hash representing the current values for the items in the
+      # passed Hash, as a subset of this Accumulator's attributes Hash.
+      #
+      # comparison - A Hash mapping of attributes to values.
+      #
+      # Returns a Hash.
+      def current(comparison)
+        attributes.each_with_object({}) do |(attribute, value), diff|
+          next unless comparison.key?(attribute)
+          diff[attribute] = value
+        end
+      end
+
       # Public: Get a Hash representing the changes that would need to be
       # applied to make a passed Hash a subset of this Accumulator's derived
       # attributes Hash.

--- a/lib/restforce/db/accumulator.rb
+++ b/lib/restforce/db/accumulator.rb
@@ -38,25 +38,9 @@ module Restforce
       #
       # Returns a Hash.
       def current(comparison)
-        attributes.each_with_object({}) do |(attribute, value), diff|
+        attributes.each_with_object({}) do |(attribute, value), final|
           next unless comparison.key?(attribute)
-          diff[attribute] = value
-        end
-      end
-
-      # Public: Get a Hash representing the changes that would need to be
-      # applied to make a passed Hash a subset of this Accumulator's derived
-      # attributes Hash.
-      #
-      # comparison - A Hash mapping of attributes to values.
-      #
-      # Returns a Hash.
-      def diff(comparison)
-        attributes.each_with_object({}) do |(attribute, value), diff|
-          next unless comparison.key?(attribute)
-          next if comparison[attribute] == value
-
-          diff[attribute] = value
+          final[attribute] = value
         end
       end
 

--- a/lib/restforce/db/adapter.rb
+++ b/lib/restforce/db/adapter.rb
@@ -13,7 +13,7 @@ module Restforce
       # attributes - A Hash of attributes, with keys corresponding to a Mapping.
       #
       # Returns a Hash.
-      def to_database(attributes)
+      def to(attributes)
         attributes.dup
       end
 
@@ -23,7 +23,7 @@ module Restforce
       # attributes - A Hash of attributes, with keys corresponding to a Mapping.
       #
       # Returns a Hash.
-      def to_salesforce(attributes)
+      def from(attributes)
         attributes.each_with_object({}) do |(key, value), final|
           value = value.utc if value.respond_to?(:utc)
           value = value.iso8601 if value.respond_to?(:iso8601)

--- a/lib/restforce/db/adapter.rb
+++ b/lib/restforce/db/adapter.rb
@@ -13,7 +13,7 @@ module Restforce
       # attributes - A Hash of attributes, with keys corresponding to a Mapping.
       #
       # Returns a Hash.
-      def to(attributes)
+      def to_database(attributes)
         attributes.dup
       end
 
@@ -23,7 +23,7 @@ module Restforce
       # attributes - A Hash of attributes, with keys corresponding to a Mapping.
       #
       # Returns a Hash.
-      def from(attributes)
+      def from_database(attributes)
         attributes.each_with_object({}) do |(key, value), final|
           value = value.utc if value.respond_to?(:utc)
           value = value.iso8601 if value.respond_to?(:iso8601)

--- a/lib/restforce/db/adapter.rb
+++ b/lib/restforce/db/adapter.rb
@@ -1,0 +1,39 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Adapter defines the default data conversions between
+    # database and Salesforce formats. It translates Dates and Times to ISO-8601
+    # format for storage in Salesforce.
+    class Adapter
+
+      # Public: Convert the passed attribute hash to a format consumable by
+      # the ActiveRecord model. By default, performs no conversions.
+      #
+      # attributes - A Hash of attributes, with keys corresponding to a Mapping.
+      #
+      # Returns a Hash.
+      def to_database(attributes)
+        attributes.dup
+      end
+
+      # Public: Convert the passed attribute hash to a format consumable by
+      # Salesforce.
+      #
+      # attributes - A Hash of attributes, with keys corresponding to a Mapping.
+      #
+      # Returns a Hash.
+      def to_salesforce(attributes)
+        attributes.each_with_object({}) do |(key, value), final|
+          value = value.utc if value.respond_to?(:utc)
+          value = value.iso8601 if value.respond_to?(:iso8601)
+
+          final[key] = value
+        end
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/attribute_map.rb
+++ b/lib/restforce/db/attribute_map.rb
@@ -4,6 +4,10 @@ module Restforce
 
     # Restforce::DB::AttributeMap encapsulates the logic for converting between
     # various representations of attribute hashes.
+    #
+    # For the purposes of our mappings, a "normalized" attribute Hash maps the
+    # Salesforce field names to Salesforce-compatible values. Value conversion
+    # into and out of the database occurs through a lightweight Adapter object.
     class AttributeMap
 
       # Public: Initialize a Restforce::DB::AttributeMap.
@@ -28,7 +32,7 @@ module Restforce
 
       # Public: Build a normalized Hash of attributes from the appropriate set
       # of mappings. The keys of the resulting mapping Hash will correspond to
-      # the database column names.
+      # the Salesforce field names.
       #
       # from_format - A String or Class reflecting the record type from which
       #               the attribute Hash is being compiled.
@@ -38,12 +42,17 @@ module Restforce
       def attributes(from_format)
         case @types[from_format]
         when :salesforce
-          @fields.each_with_object({}) do |(attribute, mapping), values|
-            values[attribute] = yield(mapping)
+          @fields.values.each_with_object({}) do |mapping, values|
+            values[mapping] = yield(mapping)
           end
         when :database
-          @fields.keys.each_with_object({}) do |attribute, values|
+          attributes = @fields.keys.each_with_object({}) do |attribute, values|
             values[attribute] = yield(attribute)
+          end
+          attributes = @adapter.from(attributes)
+
+          @fields.each_with_object({}) do |(attribute, mapping), final|
+            final[mapping] = attributes[attribute]
           end
         else
           raise ArgumentError
@@ -66,67 +75,22 @@ module Restforce
       #     some_key: "SomeField__c",
       #   )
       #
-      #   mapping.convert("Object__c", some_key: "some value")
-      #   # => { "Some_Field__c" => "some value" }
+      #   mapping.convert(MyClass, "Some_Field__c" => "some value")
+      #   # => { some_key: "some value" }
       #
-      #   mapping.convert(MyClass, some_key: "some other value")
-      #   # => { some_key: "some other value" }
+      #   mapping.convert("Object__c", "Some_Field__c" => "some other value")
+      #   # => { "Some_Field__c" => "some other value" }
       #
       # Returns a Hash.
       def convert(to_format, attributes)
         case @types[to_format]
         when :database
-          @adapter.to_database(attributes)
-        when :salesforce
-          attributes = @adapter.to_salesforce(attributes)
-
-          @fields.each_with_object({}) do |(attribute, mapping), converted|
-            next unless attributes.key?(attribute)
-            converted[mapping] = attributes[attribute]
-          end
-        else
-          raise ArgumentError
-        end
-      end
-
-      # Public: Convert a Hash of Salesforce attributes to a format compatible
-      # with a specific platform.
-      #
-      # to_format  - A String or Class reflecting the record type for which the
-      #              attribute Hash is being compiled.
-      # attributes - A Hash of attributes, with keys corresponding to the
-      #              Salesforce attribute names.
-      #
-      # Examples
-      #
-      #   map = AttributeMap.new(
-      #     MyClass,
-      #     "Object__c",
-      #     some_key: "SomeField__c",
-      #   )
-      #
-      #   map.convert_from_salesforce(
-      #     "Object__c",
-      #     "Some_Field__c" => "some value",
-      #   )
-      #   # => { "Some_Field__c" => "some value" }
-      #
-      #   map.convert_from_salesforce(
-      #     MyClass,
-      #     "Some_Field__c" => "some other value",
-      #   )
-      #   # => { some_key: "some other value" }
-      #
-      # Returns a Hash.
-      def convert_from_salesforce(to_format, attributes)
-        case @types[to_format]
-        when :database
-          final = @fields.each_with_object({}) do |(attribute, mapping), converted|
+          attributes = @fields.each_with_object({}) do |(attribute, mapping), converted|
             next unless attributes.key?(mapping)
             converted[attribute] = attributes[mapping]
           end
 
-          @adapter.to_database(final)
+          @adapter.to(attributes)
         when :salesforce
           attributes.dup
         else

--- a/lib/restforce/db/attribute_map.rb
+++ b/lib/restforce/db/attribute_map.rb
@@ -49,7 +49,7 @@ module Restforce
           attributes = @fields.keys.each_with_object({}) do |attribute, values|
             values[attribute] = yield(attribute)
           end
-          attributes = @adapter.from(attributes)
+          attributes = @adapter.from_database(attributes)
 
           @fields.each_with_object({}) do |(attribute, mapping), final|
             final[mapping] = attributes[attribute]
@@ -90,7 +90,7 @@ module Restforce
             converted[attribute] = attributes[mapping]
           end
 
-          @adapter.to(attributes)
+          @adapter.to_database(attributes)
         when :salesforce
           attributes.dup
         else

--- a/lib/restforce/db/collector.rb
+++ b/lib/restforce/db/collector.rb
@@ -47,27 +47,27 @@ module Restforce
         @accumulated_changes ||= Hash.new { |h, k| h[k] = {} }
       end
 
-      # Internal: Append the passed record's attributes to its accumulated list
+      # Internal: Append the passed instance's attributes to its accumulated list
       # of changesets.
       #
-      # record - A Restforce::DB::Instances::Base.
+      # instance - A Restforce::DB::Instances::Base.
       #
       # Returns nothing.
-      def accumulate(record)
-        accumulated_changes[key_for(record)].store(
-          record.last_update,
-          @mapping.convert(@mapping.salesforce_model, record.attributes),
+      def accumulate(instance)
+        accumulated_changes[key_for(instance)].store(
+          instance.last_update,
+          instance.attributes,
         )
       end
 
       # Internal: Get a unique key with enough information to look up the passed
-      # record in Salesforce.
+      # instance in Salesforce.
       #
-      # record - A Restforce::DB::Instances::Base.
+      # instance - A Restforce::DB::Instances::Base.
       #
       # Returns an Object.
-      def key_for(record)
-        [record.id, record.mapping.salesforce_model]
+      def key_for(instance)
+        [instance.id, instance.mapping.salesforce_model]
       end
 
     end

--- a/lib/restforce/db/dsl.rb
+++ b/lib/restforce/db/dsl.rb
@@ -97,14 +97,14 @@ module Restforce
       # Public: Define a set of adapters which should be used to translate data
       # between the database and Salesforce.
       #
-      # adapter - A Hash, with keys corresponding to attributes of the database
-      #           record, and adapter objects as values.
+      # adapter - An adapter object, which converts an attribute Hash between
+      #           normalized and database-ready formats.
       #
-      # Raises ArgumentError if any adapter object has an incomplete interface.
+      # Raises ArgumentError if the adapter object has an incomplete interface.
       # Returns nothing.
       def converts_with(adapter)
-        unless adapter.respond_to?(:to_database) && adapter.respond_to?(:to_salesforce)
-          raise ArgumentError, "Your adapter must implement `to_database` and `to_salesforce` methods"
+        unless adapter.respond_to?(:to) && adapter.respond_to?(:from)
+          raise ArgumentError, "Your adapter must implement `to` and `from` methods"
         end
 
         @mapping.adapter = adapter

--- a/lib/restforce/db/dsl.rb
+++ b/lib/restforce/db/dsl.rb
@@ -103,8 +103,8 @@ module Restforce
       # Raises ArgumentError if the adapter object has an incomplete interface.
       # Returns nothing.
       def converts_with(adapter)
-        unless adapter.respond_to?(:to) && adapter.respond_to?(:from)
-          raise ArgumentError, "Your adapter must implement `to` and `from` methods"
+        unless adapter.respond_to?(:to_database) && adapter.respond_to?(:from_database)
+          raise ArgumentError, "Your adapter must implement `to_database` and `from_database` methods"
         end
 
         @mapping.adapter = adapter

--- a/lib/restforce/db/dsl.rb
+++ b/lib/restforce/db/dsl.rb
@@ -97,17 +97,17 @@ module Restforce
       # Public: Define a set of adapters which should be used to translate data
       # between the database and Salesforce.
       #
-      # fields - A Hash, with keys corresponding to attributes of the database
-      #          record, and adapter objects as values.
+      # adapter - A Hash, with keys corresponding to attributes of the database
+      #           record, and adapter objects as values.
       #
       # Raises ArgumentError if any adapter object has an incomplete interface.
       # Returns nothing.
-      def converts(conversions)
-        unless conversions.values.all? { |c| c.respond_to?(:to_database) && c.respond_to?(:to_salesforce) }
-          raise ArgumentError, "All adapters must implement `to_database` and `to_salesforce` methods"
+      def converts_with(adapter)
+        unless adapter.respond_to?(:to_database) && adapter.respond_to?(:to_salesforce)
+          raise ArgumentError, "Your adapter must implement `to_database` and `to_salesforce` methods"
         end
 
-        @mapping.conversions = conversions
+        @mapping.adapter = adapter
       end
 
     end

--- a/lib/restforce/db/mapping.rb
+++ b/lib/restforce/db/mapping.rb
@@ -25,8 +25,8 @@ module Restforce
       )
 
       attr_accessor(
+        :adapter,
         :fields,
-        :conversions,
         :associations,
         :conditions,
         :strategy,
@@ -44,8 +44,8 @@ module Restforce
         @database_record_type = RecordTypes::ActiveRecord.new(database_model, self)
         @salesforce_record_type = RecordTypes::Salesforce.new(salesforce_model, self)
 
+        self.adapter = Adapter.new
         self.fields = {}
-        self.conversions = {}
         self.associations = []
         self.conditions = []
         self.strategy = strategy
@@ -109,7 +109,7 @@ module Restforce
       #
       # Returns a Restforce::DB::AttributeMap.
       def attribute_map
-        @attribute_map ||= AttributeMap.new(database_model, salesforce_model, fields, conversions)
+        @attribute_map ||= AttributeMap.new(database_model, salesforce_model, fields, adapter)
       end
 
     end

--- a/lib/restforce/db/mapping.rb
+++ b/lib/restforce/db/mapping.rb
@@ -14,7 +14,6 @@ module Restforce
         :attribute_map,
         :attributes,
         :convert,
-        :convert_from_salesforce,
       )
 
       attr_reader(

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -49,8 +49,8 @@ module Restforce
       #
       # Returns nothing.
       def update(instance, accumulator)
-        diff = accumulator.diff(@mapping.convert(@mapping.salesforce_model, instance.attributes))
-        attributes = @mapping.convert(instance.record_type, diff)
+        current_attributes = accumulator.current(instance.attributes)
+        attributes = @mapping.convert(instance.record_type, current_attributes)
 
         return if attributes.empty?
         instance.update!(attributes)

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -50,7 +50,7 @@ module Restforce
       # Returns nothing.
       def update(instance, accumulator)
         diff = accumulator.diff(@mapping.convert(@mapping.salesforce_model, instance.attributes))
-        attributes = @mapping.convert_from_salesforce(instance.record_type, diff)
+        attributes = @mapping.convert(instance.record_type, diff)
 
         return if attributes.empty?
         instance.update!(attributes)

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -80,23 +80,4 @@ describe Restforce::DB::Accumulator do
       )
     end
   end
-
-  describe "#diff" do
-    let(:attributes) { { wocket: "Pocket", jertain: "Curtain", zelf: "Shelf" } }
-
-    before do
-      accumulator.store(Time.now, attributes)
-    end
-
-    it "returns the differences from the attributes hash" do
-      expect(accumulator.diff(wocket: "Locket", zelf: "Belfrey")).to_equal(
-        wocket: "Pocket",
-        zelf: "Shelf",
-      )
-    end
-
-    it "ignores attributes not set in the Accumulator" do
-      expect(accumulator.diff(yottle: "Bottle")).to_be :empty?
-    end
-  end
 end

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -65,6 +65,22 @@ describe Restforce::DB::Accumulator do
     end
   end
 
+  describe "#current" do
+    let(:attributes) { { wocket: "Pocket", jertain: "Curtain", zelf: "Shelf" } }
+
+    before do
+      accumulator.store(Time.now, attributes)
+    end
+
+    it "returns the current values for all attributes in the passed hash" do
+      expect(accumulator.current(wocket: "Locket")).to_equal(wocket: "Pocket")
+      expect(accumulator.current(jertain: "Curtain", zelf: "Belfrey")).to_equal(
+        jertain: "Curtain",
+        zelf: "Shelf",
+      )
+    end
+  end
+
   describe "#diff" do
     let(:attributes) { { wocket: "Pocket", jertain: "Curtain", zelf: "Shelf" } }
 

--- a/test/lib/restforce/db/adapter_test.rb
+++ b/test/lib/restforce/db/adapter_test.rb
@@ -7,16 +7,16 @@ describe Restforce::DB::Adapter do
   let(:adapter) { Restforce::DB::Adapter.new }
   let(:attributes) { { where: "Here", when: Time.now } }
 
-  describe "#to_database" do
-    let(:results) { adapter.to_database(attributes) }
+  describe "#to" do
+    let(:results) { adapter.to(attributes) }
 
     it "returns the passed attributes, unchanged" do
       expect(results).to_equal attributes
     end
   end
 
-  describe "#to_salesforce" do
-    let(:results) { adapter.to_salesforce(attributes) }
+  describe "#from" do
+    let(:results) { adapter.from(attributes) }
 
     it "converts times to ISO-8601 timestamps" do
       expect(results[:when]).to_equal attributes[:when].utc.iso8601

--- a/test/lib/restforce/db/adapter_test.rb
+++ b/test/lib/restforce/db/adapter_test.rb
@@ -7,16 +7,16 @@ describe Restforce::DB::Adapter do
   let(:adapter) { Restforce::DB::Adapter.new }
   let(:attributes) { { where: "Here", when: Time.now } }
 
-  describe "#to" do
-    let(:results) { adapter.to(attributes) }
+  describe "#to_database" do
+    let(:results) { adapter.to_database(attributes) }
 
     it "returns the passed attributes, unchanged" do
       expect(results).to_equal attributes
     end
   end
 
-  describe "#from" do
-    let(:results) { adapter.from(attributes) }
+  describe "#from_database" do
+    let(:results) { adapter.from_database(attributes) }
 
     it "converts times to ISO-8601 timestamps" do
       expect(results[:when]).to_equal attributes[:when].utc.iso8601

--- a/test/lib/restforce/db/adapter_test.rb
+++ b/test/lib/restforce/db/adapter_test.rb
@@ -1,0 +1,29 @@
+require_relative "../../../test_helper"
+
+describe Restforce::DB::Adapter do
+
+  configure!
+
+  let(:adapter) { Restforce::DB::Adapter.new }
+  let(:attributes) { { where: "Here", when: Time.now } }
+
+  describe "#to_database" do
+    let(:results) { adapter.to_database(attributes) }
+
+    it "returns the passed attributes, unchanged" do
+      expect(results).to_equal attributes
+    end
+  end
+
+  describe "#to_salesforce" do
+    let(:results) { adapter.to_salesforce(attributes) }
+
+    it "converts times to ISO-8601 timestamps" do
+      expect(results[:when]).to_equal attributes[:when].utc.iso8601
+    end
+
+    it "leaves other attributes unchanged" do
+      expect(results[:where]).to_equal attributes[:where]
+    end
+  end
+end

--- a/test/lib/restforce/db/attribute_map_test.rb
+++ b/test/lib/restforce/db/attribute_map_test.rb
@@ -28,7 +28,7 @@ describe Restforce::DB::AttributeMap do
         attribute
       end
 
-      expect(attributes.keys).to_equal(mapping.database_fields)
+      expect(attributes.keys).to_equal(mapping.salesforce_fields)
       expect(attributes.values).to_equal(mapping.database_fields)
     end
 
@@ -38,70 +38,32 @@ describe Restforce::DB::AttributeMap do
         attribute
       end
 
-      expect(attributes.keys).to_equal(mapping.database_fields)
+      expect(attributes.keys).to_equal(mapping.salesforce_fields)
       expect(attributes.values).to_equal(mapping.salesforce_fields)
     end
   end
 
   describe "#convert" do
-    let(:attributes) { { column_one: "some value" } }
-
-    it "converts an attribute Hash to a Salesforce-compatible form" do
-      expect(attribute_map.convert(salesforce_model, attributes)).to_equal(
-        fields[attributes.keys.first] => attributes.values.first,
-      )
-    end
-
-    it "performs no special conversion for database columns" do
-      expect(attribute_map.convert(database_model, attributes)).to_equal(attributes)
-    end
-
-    describe "when one of the attributes is a Date or Time" do
-      let(:timestamp) { Time.now }
-      let(:attributes) { { column_one: timestamp } }
-
-      it "converts the attribute to an ISO-8601 string for Salesforce" do
-        expect(attribute_map.convert(salesforce_model, attributes)).to_equal(
-          fields[attributes.keys.first] => timestamp.utc.iso8601,
-        )
-      end
-    end
-
-    describe "when an adapter has been defined for an attribute" do
-      let(:adapter) { boolean_adapter }
-
-      it "uses the adapter to convert that attribute to a Salesforce-compatible form" do
-        expect(attribute_map.convert(salesforce_model, column_one: true)).to_equal(
-          "SF_Field_One__c" => "Yes",
-        )
-        expect(attribute_map.convert(salesforce_model, column_one: false)).to_equal(
-          "SF_Field_One__c" => "No",
-        )
-      end
-    end
-  end
-
-  describe "#convert_from_salesforce" do
     let(:attributes) { { "SF_Field_One__c" => "some value" } }
 
+    it "converts an attribute Hash to a Salesforce-compatible form" do
+      expect(attribute_map.convert(salesforce_model, attributes)).to_equal(attributes)
+    end
+
     it "converts an attribute Hash to a database-compatible form" do
-      expect(attribute_map.convert_from_salesforce(database_model, attributes)).to_equal(
+      expect(attribute_map.convert(database_model, attributes)).to_equal(
         fields.key(attributes.keys.first) => attributes.values.first,
       )
     end
 
-    it "performs no special conversion for Salesforce fields" do
-      expect(attribute_map.convert_from_salesforce(salesforce_model, attributes)).to_equal(attributes)
-    end
-
-    describe "when a special adapter has been defined" do
+    describe "when an adapter has been specified" do
       let(:adapter) { boolean_adapter }
 
       it "uses the adapter to convert attributes to a database-compatible form" do
-        expect(attribute_map.convert_from_salesforce(database_model, "SF_Field_One__c" => "Yes")).to_equal(
+        expect(attribute_map.convert(database_model, "SF_Field_One__c" => "Yes")).to_equal(
           column_one: true,
         )
-        expect(attribute_map.convert_from_salesforce(database_model, "SF_Field_One__c" => "No")).to_equal(
+        expect(attribute_map.convert(database_model, "SF_Field_One__c" => "No")).to_equal(
           column_one: false,
         )
       end

--- a/test/lib/restforce/db/dsl_test.rb
+++ b/test/lib/restforce/db/dsl_test.rb
@@ -99,20 +99,19 @@ describe Restforce::DB::DSL do
     end
   end
 
-  describe "#converts" do
+  describe "#converts_with" do
     let(:adapter) { boolean_adapter }
-    let(:conversions) { { some: adapter } }
 
     it "sets the conversions for the created mapping" do
-      dsl.converts conversions
-      expect(mapping.conversions).to_equal conversions
+      dsl.converts_with adapter
+      expect(mapping.adapter).to_equal adapter
     end
 
     describe "when the adapter does not define the expected methods" do
       let(:adapter) { Object.new }
 
       it "raises an ArgumentError" do
-        expect(-> { dsl.converts conversions }).to_raise ArgumentError
+        expect(-> { dsl.converts_with adapter }).to_raise ArgumentError
       end
     end
   end

--- a/test/lib/restforce/db/record_types/active_record_test.rb
+++ b/test/lib/restforce/db/record_types/active_record_test.rb
@@ -11,8 +11,8 @@ describe Restforce::DB::RecordTypes::ActiveRecord do
   describe "#create!" do
     let(:attributes) do
       {
-        name:    "Some name",
-        example: "Some text",
+        "Name"             => "Some name",
+        "Example_Field__c" => "Some text",
       }
     end
     let(:record) { nil }
@@ -32,8 +32,8 @@ describe Restforce::DB::RecordTypes::ActiveRecord do
 
     it "creates a record in the database from the passed Salesforce record's attributes" do
       expect(instance.salesforce_id).to_equal salesforce_id
-      expect(instance.name).to_equal attributes[:name]
-      expect(instance.example).to_equal attributes[:example]
+      expect(instance.name).to_equal attributes["Name"]
+      expect(instance.example).to_equal attributes["Example_Field__c"]
       expect(instance.synchronized_at).to_not_be_nil
     end
 
@@ -64,7 +64,7 @@ describe Restforce::DB::RecordTypes::ActiveRecord do
             id,
             Time.now,
             Restforce::DB::Registry[User].first,
-            email: "somebody@example.com",
+            "Email" => "somebody@example.com",
           )
         end
       end

--- a/test/lib/restforce/db/synchronizer_test.rb
+++ b/test/lib/restforce/db/synchronizer_test.rb
@@ -10,20 +10,15 @@ describe Restforce::DB::Synchronizer do
   describe "#run", vcr: { match_requests_on: [:method, VCR.request_matchers.uri_without_param(:q)] } do
     let(:attributes) do
       {
-        name:    "Custom object",
-        example: "Some sample text",
+        "Name"             => "Custom object",
+        "Example_Field__c" => "Some sample text",
       }
     end
-    let(:salesforce_id) do
-      Salesforce.create!(
-        salesforce_model,
-        mapping.convert(salesforce_model, attributes),
-      )
-    end
+    let(:salesforce_id) { Salesforce.create!(salesforce_model, attributes) }
     let(:changes) { { [salesforce_id, salesforce_model] => accumulator } }
     let(:new_attributes) do
       {
-        "Name" => "Some new name",
+        "Name"             => "Some new name",
         "Example_Field__c" => "New sample text",
       }
     end

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -31,13 +31,13 @@ end
 def boolean_adapter
   Object.new.tap do |object|
 
-    def object.to(attributes)
+    def object.to_database(attributes)
       attributes.each_with_object({}) do |(k, v), final|
         final[k] = (v == "Yes")
       end
     end
 
-    def object.from(attributes)
+    def object.from_database(attributes)
       attributes.each_with_object({}) do |(k, v), final|
         final[k] = v ? "Yes" : "No"
       end

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -31,12 +31,16 @@ end
 def boolean_adapter
   Object.new.tap do |object|
 
-    def object.to_database(value)
-      value == "Yes"
+    def object.to_database(attributes)
+      attributes.each_with_object({}) do |(k, v), final|
+        final[k] = (v == "Yes")
+      end
     end
 
-    def object.to_salesforce(value)
-      value ? "Yes" : "No"
+    def object.to_salesforce(attributes)
+      attributes.each_with_object({}) do |(k, v), final|
+        final[k] = v ? "Yes" : "No"
+      end
     end
 
   end

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -31,13 +31,13 @@ end
 def boolean_adapter
   Object.new.tap do |object|
 
-    def object.to_database(attributes)
+    def object.to(attributes)
       attributes.each_with_object({}) do |(k, v), final|
         final[k] = (v == "Yes")
       end
     end
 
-    def object.to_salesforce(attributes)
+    def object.from(attributes)
       attributes.each_with_object({}) do |(k, v), final|
         final[k] = v ? "Yes" : "No"
       end


### PR DESCRIPTION
In some use cases, it’s helpful to be able to add/remove keys from the
final Hash that is fed into an ActiveRecord object’s attributes, or to
perform logic checks across multiple values. To this end, it makes sense
to replace our single-column value adapters with a single holistic 
“Adapter” object per mapping.