### PR TITLE
Allow api_version to be specified in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ For additional information and a full set of options, you can run:
 - **API Usage.** 
   This gem performs most of its functionality via the Salesforce API (by way of the [`restforce`](https://github.com/ejholmes/restforce) gem). If you're at risk of hitting your Salesforce API limits, this may not be the right approach for you.
 
+- **API Version.**
+  Restforce::DB defaults to version 29.0 of the Salesforce API. If you need a more (or less, for whatever reason) recent version of the API for your use case, you can specify an `api_version` key in your restforce-db.yml configuration. Version 29.0 or above is required for full gem functionality.
+
 - **Update Prioritization.**
   When synchronization occurs, the most recently updated record, Salesforce or database, gets to make the final call about the values of _all_ of the fields it observes. This means that race conditions can and probably will happen if both systems are updated within the same polling interval.
 

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -78,6 +78,7 @@ module Restforce
         client_id:      configuration.client_id,
         client_secret:  configuration.client_secret,
         host:           configuration.host,
+        api_version:    configuration.api_version,
       )
     end
 

--- a/lib/restforce/db/configuration.rb
+++ b/lib/restforce/db/configuration.rb
@@ -8,6 +8,8 @@ module Restforce
     # and read methods to allow users to configure Restforce::DB.
     class Configuration
 
+      DEFAULT_API_VERSION = "29.0".freeze
+
       attr_accessor(*%i(
         username
         password
@@ -15,6 +17,7 @@ module Restforce
         client_id
         client_secret
         host
+        api_version
       ))
 
       # Public: Parse a supplied YAML file for a set of credentials, and use
@@ -41,6 +44,10 @@ module Restforce
         self.client_id      = parsed(configurations, "client_id")
         self.client_secret  = parsed(configurations, "client_secret")
         self.host           = parsed(configurations, "host")
+
+        # We want to default to 29.0 or later, so we can support the API
+        # endpoint for recently deleted records.
+        self.api_version    = configurations["api_version"] || DEFAULT_API_VERSION
       end
 
       private

--- a/test/cassettes/Restforce_DB/accessing_Salesforce/uses_the_configured_credentials.yml
+++ b/test/cassettes/Restforce_DB/accessing_Salesforce/uses_the_configured_credentials.yml
@@ -38,6 +38,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427365218093","token_type":"Bearer","instance_url":"https://<host>","signature":"zr8yut/9lhLfOwHlsCXPJ635XLUaIg62ecMRMW7mAV4=","access_token":"00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:18 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428631827849","token_type":"Bearer","instance_url":"https://<host>","signature":"BXGR8ydlpCf8EvBey3owrmD+t8H2Xwv4wg5rPNZH7o0=","access_token":"00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:29 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=11/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001y45eAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001y45eAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:30 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001y45eAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=11/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2EAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LS2EAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:31 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2EAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2EAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2EAAW"},"Id":"a001a000001LS2EAAW","SystemModstamp":"2015-04-10T02:10:31.000+0000","Name":"a001a000001LS2E","Example_Field__c":null,"Friend__c":"0031a000001y45eAAA"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW"},"Id":"a001a000001LS2EAAW","SystemModstamp":"2015-04-10T02:10:31.000+0000","Name":"a001a000001LS2E","Example_Field__c":null,"Friend__c":"0031a000001y45eAAA"}]}'
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001y45eAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001y45eAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000001y45eAAA"},"Id":"0031a000001y45eAAA","SystemModstamp":"2015-04-10T02:10:30.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA"},"Id":"0031a000001y45eAAA","SystemModstamp":"2015-04-10T02:10:30.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:33 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001y45eAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:34 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2EAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:10:35 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557930126","token_type":"Bearer","instance_url":"https://<host>","signature":"r67C8yGA3MlpIHibA9/5ixX6k3b4vIgUwX+3d1iC3Qs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:25:30 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":null}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=13/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001MG7WAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:25:31 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MG7WAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MG7WAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,12 +117,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW"},"Id":"a001a000001MG7WAAW","SystemModstamp":"2015-04-20T19:25:31.000+0000","Name":"a001a000001MG7W","Example_Field__c":null,"Friend__c":null}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW"},"Id":"a001a000001MG7WAAW","SystemModstamp":"2015-04-20T19:25:31.000+0000","Name":"a001a000001MG7W","Example_Field__c":null,"Friend__c":null}]}'
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:25:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%27%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%27%27
     body:
       encoding: US-ASCII
       string: ''
@@ -156,11 +156,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:25:33 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001MG7WAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -190,6 +190,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:25:34 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429810394922","token_type":"Bearer","instance_url":"https://<host>","signature":"qD5Hnlij9mqvLquOno/CQKE+/oNFSOhawRLJvX4MVpE=","access_token":"00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:15 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=13/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002fBHlAAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002fBHlAAM","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:16 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002fBHlAAM"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=13/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhqAAC"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001QmhqAAC","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhqAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhqAAC%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhqAAC"},"Id":"a001a000001QmhqAAC","SystemModstamp":"2015-04-23T17:33:17.000+0000","Name":"a001a000001Qmhq","Example_Field__c":null,"Friend__c":"0031a000002fBHlAAM"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC"},"Id":"a001a000001QmhqAAC","SystemModstamp":"2015-04-23T17:33:17.000+0000","Name":"a001a000001Qmhq","Example_Field__c":null,"Friend__c":"0031a000002fBHlAAM"}]}'
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002fBHlAAM%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002fBHlAAM%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002fBHlAAM"},"Id":"0031a000002fBHlAAM","SystemModstamp":"2015-04-23T17:33:16.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM"},"Id":"0031a000002fBHlAAM","SystemModstamp":"2015-04-23T17:33:16.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002fBHlAAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:20 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhqAAC
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:33:21 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430498004388","token_type":"Bearer","instance_url":"https://<host>","signature":"UlHQTMd5UMeQOcODXUr6CtDraNkn2Wq50gFTzKBlpT8=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:24 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=14/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002jr5yAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002jr5yAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:24 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002jr5yAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=14/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuPCAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001TuPCAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:25 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuPCAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuPCAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuPCAA0"},"Id":"a001a000001TuPCAA0","SystemModstamp":"2015-05-01T16:33:24.000+0000","Name":"a001a000001TuPC","Example_Field__c":null,"Friend__c":"0031a000002jr5yAAA"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0"},"Id":"a001a000001TuPCAA0","SystemModstamp":"2015-05-01T16:33:24.000+0000","Name":"a001a000001TuPC","Example_Field__c":null,"Friend__c":"0031a000002jr5yAAA"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:25 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5yAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5yAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002jr5yAAA"},"Id":"0031a000002jr5yAAA","SystemModstamp":"2015-05-01T16:33:24.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA"},"Id":"0031a000002jr5yAAA","SystemModstamp":"2015-05-01T16:33:24.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:25 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002jr5yAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:25 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuPCAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:26 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460634690","token_type":"Bearer","instance_url":"https://<host>","signature":"I1sgPTyHS2c7Q4mY6uYgi366rdlGdYcRwz3opVrE+58=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:14 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003Gm5NAAS"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003Gm5NAAS"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003Gm5NAAS","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:16 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003Gm5NAAS"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=2/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKKDAA4"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZKKDAA4","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKKDAA4%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKKDAA4%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKKDAA4"},"Id":"a001a000001ZKKDAA4","SystemModstamp":"2015-05-12T19:57:17.000+0000","Name":"a001a000001ZKKD","Example_Field__c":null,"Friend__c":"0031a000003Gm5NAAS"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4"},"Id":"a001a000001ZKKDAA4","SystemModstamp":"2015-05-12T19:57:17.000+0000","Name":"a001a000001ZKKD","Example_Field__c":null,"Friend__c":"0031a000003Gm5NAAS"}]}'
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003Gm5NAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003Gm5NAAS
     body:
       encoding: US-ASCII
       string: ''
@@ -194,11 +194,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKKDAA4
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4
     body:
       encoding: US-ASCII
       string: ''
@@ -228,6 +228,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/with_an_unrelated_association_mapping/proceeds_without_raising_an_error.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/with_an_unrelated_association_mapping/proceeds_without_raising_an_error.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429758817565","token_type":"Bearer","instance_url":"https://<host>","signature":"ETRbdU1qbtTF4bZuRhnk3OFfLRmxZRMXihMo3PgUaCc=","access_token":"00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:37 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002eu2wAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:39 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002eu2wAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001QkMJAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:40 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QkMJAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QkMJAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0"},"Id":"a001a000001QkMJAA0","SystemModstamp":"2015-04-23T03:13:40.000+0000","Name":"a001a000001QkMJ","Example_Field__c":null,"Friend__c":"0031a000002eu2wAAA"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0"},"Id":"a001a000001QkMJAA0","SystemModstamp":"2015-04-23T03:13:40.000+0000","Name":"a001a000001QkMJ","Example_Field__c":null,"Friend__c":"0031a000002eu2wAAA"}]}'
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:41 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002eu2wAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002eu2wAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA"},"Id":"0031a000002eu2wAAA","SystemModstamp":"2015-04-23T03:13:38.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA"},"Id":"0031a000002eu2wAAA","SystemModstamp":"2015-04-23T03:13:38.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:42 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002eu2wAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:43 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001QkMJAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 03:13:44 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430708626705","token_type":"Bearer","instance_url":"https://<host>","signature":"l9dFCE7hnrj+RVNOaga2AVC08CivElFFEXzzLx249cg=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:03:46 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=62/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a00000317qmAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a00000317qmAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a00000317qmAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:03:47 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a00000317qmAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=62/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16LAAS"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16LAAS"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001U16LAAS","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:03:49 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a00000317qmAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a00000317qmAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -156,11 +156,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:03:50 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16LAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16LAAS
     body:
       encoding: US-ASCII
       string: ''
@@ -190,6 +190,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:03:51 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430709113521","token_type":"Bearer","instance_url":"https://<host>","signature":"2BWFc3pyXdIWgSNtXnE+OpZDdD+Oas7Mk3KKVvtfEzw=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:11:53 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=66/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16VAAS"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16VAAS"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001U16VAAS","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:11:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001U16VAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16VAAS
     body:
       encoding: US-ASCII
       string: ''
@@ -114,6 +114,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 04 May 2015 03:11:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715430707","token_type":"Bearer","instance_url":"https://<host>","signature":"GqowJrZwZnvh/FQmaN/zR2DJsm9BQNYlk+S4ewYO+s4=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:51 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=103/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001yZN7AAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZN7AAM"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001yZN7AAM","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:53 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001yZN7AAM"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=104/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgVAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgVAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:54 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:56 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:58 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001yZN7AAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZN7AAM
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:59 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgVAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:24:00 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715392140","token_type":"Bearer","instance_url":"https://<host>","signature":"bcg+FhBqe0ZyHpYd43tkTmXlDCi8iyF0A98BQ01cUaY=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:12 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=100/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001yZN2AAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZN2AAM"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001yZN2AAM","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:14 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001yZN2AAM"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=100/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgKAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgKAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:16 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001yZN2AAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZN2AAM
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgKAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:23:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/builds_a_number_of_associated_records_from_the_data_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/builds_a_number_of_associated_records_from_the_data_in_Salesforce.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428634672541","token_type":"Bearer","instance_url":"https://<host>","signature":"+Yw0d+DUcrlkXfNTN9OldvMmsaQIzIfxRVOXzMBfzrA=","access_token":"00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:52 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=48/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2dAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LS2dAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:54 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"First Detail","CustomObject__c":"a001a000001LS2dAAG"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=48/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gvbNAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:55 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Second Detail","CustomObject__c":"a001a000001LS2dAAG"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=48/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gvbSAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:57 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Third Detail","CustomObject__c":"a001a000001LS2dAAG"}'
@@ -198,7 +198,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=49/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -206,11 +206,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gvbXAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:58 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2dAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2dAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -243,13 +243,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2dAAG"},"Id":"a001a000001LS2dAAG","SystemModstamp":"2015-04-10T02:57:54.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG"},"Id":"a001a000001LS2dAAG","SystemModstamp":"2015-04-10T02:57:54.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:57:59 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LS2dAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LS2dAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -282,15 +282,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"},"Id":"a011a000000gvbNAAQ","SystemModstamp":"2015-04-10T02:57:55.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"},"Id":"a011a000000gvbXAAQ","SystemModstamp":"2015-04-10T02:57:58.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"},"Id":"a011a000000gvbSAAQ","SystemModstamp":"2015-04-10T02:57:57.000+0000","Name":"Second
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"},"Id":"a011a000000gvbNAAQ","SystemModstamp":"2015-04-10T02:57:55.000+0000","Name":"First
+        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"},"Id":"a011a000000gvbXAAQ","SystemModstamp":"2015-04-10T02:57:58.000+0000","Name":"Third
+        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"},"Id":"a011a000000gvbSAAQ","SystemModstamp":"2015-04-10T02:57:57.000+0000","Name":"Second
         Detail","CustomObject__c":"a001a000001LS2dAAG"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:58:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LS2dAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -320,11 +320,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:58:01 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:58:03 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:58:04 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 02:58:06 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557478143","token_type":"Bearer","instance_url":"https://<host>","signature":"ra/+CwNB4ZgXs5e+MFICh3OTNXzz5U4pVS+WeaUDLAU=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:17:58 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=5/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001MFzDAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:17:59 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MFzDAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MFzDAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW"},"Id":"a001a000001MFzDAAW","SystemModstamp":"2015-04-20T19:17:59.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW"},"Id":"a001a000001MFzDAAW","SystemModstamp":"2015-04-20T19:17:59.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:18:00 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001MFzDAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001MFzDAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -157,11 +157,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:18:01 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001MFzDAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -191,6 +191,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:18:02 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_alrady_been_persisted/constructs_the_association_from_the_existing_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_alrady_been_persisted/constructs_the_association_from_the_existing_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429810822356","token_type":"Bearer","instance_url":"https://<host>","signature":"KsYGkglGxb+rYOwCQ8vWPs/HDGolddk5RrRN6T/WDMw=","access_token":"00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:22 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=19/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhvAAC"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001QmhvAAC","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:23 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"First Detail","CustomObject__c":"a001a000001QmhvAAC"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=19/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i200AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000i200AAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:25 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Second Detail","CustomObject__c":"a001a000001QmhvAAC"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=19/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i205AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000i205AAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:26 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Third Detail","CustomObject__c":"a001a000001QmhvAAC"}'
@@ -198,7 +198,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=20/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -206,11 +206,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000i20AAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhvAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhvAAC%27
     body:
       encoding: US-ASCII
       string: ''
@@ -243,13 +243,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhvAAC"},"Id":"a001a000001QmhvAAC","SystemModstamp":"2015-04-23T17:40:23.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC"},"Id":"a001a000001QmhvAAC","SystemModstamp":"2015-04-23T17:40:23.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001QmhvAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001QmhvAAC%27
     body:
       encoding: US-ASCII
       string: ''
@@ -282,15 +282,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i200AAA"},"Id":"a011a000000i200AAA","SystemModstamp":"2015-04-23T17:40:24.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"},"Id":"a011a000000i20AAAQ","SystemModstamp":"2015-04-23T17:40:27.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i205AAA"},"Id":"a011a000000i205AAA","SystemModstamp":"2015-04-23T17:40:26.000+0000","Name":"Second
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA"},"Id":"a011a000000i200AAA","SystemModstamp":"2015-04-23T17:40:24.000+0000","Name":"First
+        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"},"Id":"a011a000000i20AAAQ","SystemModstamp":"2015-04-23T17:40:27.000+0000","Name":"Third
+        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA"},"Id":"a011a000000i205AAA","SystemModstamp":"2015-04-23T17:40:26.000+0000","Name":"Second
         Detail","CustomObject__c":"a001a000001QmhvAAC"}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:29 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001QmhvAAC
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC
     body:
       encoding: US-ASCII
       string: ''
@@ -320,11 +320,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:30 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i200AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA
     body:
       encoding: US-ASCII
       string: ''
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:31 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i205AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA
     body:
       encoding: US-ASCII
       string: ''
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:32 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 23 Apr 2015 17:40:33 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_been_cached/uses_the_cached_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_been_cached/uses_the_cached_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430497646270","token_type":"Bearer","instance_url":"https://<host>","signature":"fJPCXmLPScmZ35fJC8zeUl/q4GP4NMEjirHl+vGtLcs=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:26 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuOxAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001TuOxAAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:27 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"First Detail","CustomObject__c":"a001a000001TuOxAAK"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000ikfZAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:27 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Second Detail","CustomObject__c":"a001a000001TuOxAAK"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000ikfeAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:27 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Third Detail","CustomObject__c":"a001a000001TuOxAAK"}'
@@ -198,7 +198,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -206,11 +206,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000ikfjAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuOxAAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuOxAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -243,13 +243,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuOxAAK"},"Id":"a001a000001TuOxAAK","SystemModstamp":"2015-05-01T16:27:26.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK"},"Id":"a001a000001TuOxAAK","SystemModstamp":"2015-05-01T16:27:26.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001TuOxAAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001TuOxAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -282,15 +282,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"},"Id":"a011a000000ikfjAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"},"Id":"a011a000000ikfZAAQ","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"},"Id":"a011a000000ikfeAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Second
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"},"Id":"a011a000000ikfjAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Third
+        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"},"Id":"a011a000000ikfZAAQ","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"First
+        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"},"Id":"a011a000000ikfeAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Second
         Detail","CustomObject__c":"a001a000001TuOxAAK"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuOxAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -320,11 +320,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:29 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:29 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:29 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:27:29 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460619986","token_type":"Bearer","instance_url":"https://<host>","signature":"u64BZdZBkpV7s2sYs1cc+mLttOxfG+RQh+VA+afErCc=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:56:59 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKK3AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZKK3AAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:01 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKK3AAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKK3AAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKK3AAO"},"Id":"a001a000001ZKK3AAO","SystemModstamp":"2015-05-12T19:57:01.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO"},"Id":"a001a000001ZKK3AAO","SystemModstamp":"2015-05-12T19:57:01.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:02 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKK3AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:03 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715785563","token_type":"Bearer","instance_url":"https://<host>","signature":"CP3JKuG7/SQHR4Dam1HfpVtvW2QDAn8O0aTFO+2REEg=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:46 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=170/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgyAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgyAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:47 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"First Detail","CustomObject__c":"a001a000001LXgyAAG"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=170/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gym7AAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:48 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Second Detail","CustomObject__c":"a001a000001LXgyAAG"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=170/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gylUAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:49 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"Name":"Third Detail","CustomObject__c":"a001a000001LXgyAAG"}'
@@ -198,7 +198,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=170/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -206,11 +206,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gymCAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:50 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgyAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgyAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -243,13 +243,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgyAAG"},"Id":"a001a000001LXgyAAG","SystemModstamp":"2015-04-11T01:29:46.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG"},"Id":"a001a000001LXgyAAG","SystemModstamp":"2015-04-11T01:29:46.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:51 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXgyAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXgyAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -282,15 +282,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"},"Id":"a011a000000gylUAAQ","SystemModstamp":"2015-04-11T01:29:48.000+0000","Name":"Second
-        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"},"Id":"a011a000000gym7AAA","SystemModstamp":"2015-04-11T01:29:47.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"},"Id":"a011a000000gymCAAQ","SystemModstamp":"2015-04-11T01:29:49.000+0000","Name":"Third
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"},"Id":"a011a000000gylUAAQ","SystemModstamp":"2015-04-11T01:29:48.000+0000","Name":"Second
+        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"},"Id":"a011a000000gym7AAA","SystemModstamp":"2015-04-11T01:29:47.000+0000","Name":"First
+        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"},"Id":"a011a000000gymCAAQ","SystemModstamp":"2015-04-11T01:29:49.000+0000","Name":"Third
         Detail","CustomObject__c":"a001a000001LXgyAAG"}]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:52 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgyAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -320,11 +320,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:53 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gym7AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA
     body:
       encoding: US-ASCII
       string: ''
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:55 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:57 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715798755","token_type":"Bearer","instance_url":"https://<host>","signature":"/GkLEgWKmoxA2MrX0e/J3mV+I37ybalQOsRqYmS4YNU=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:29:59 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=170/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXh3AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXh3AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:30:00 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXh3AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXh3AAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXh3AAG"},"Id":"a001a000001LXh3AAG","SystemModstamp":"2015-04-11T01:30:00.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG"},"Id":"a001a000001LXh3AAG","SystemModstamp":"2015-04-11T01:30:00.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:30:01 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXh3AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXh3AAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -157,11 +157,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:30:02 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXh3AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -191,6 +191,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:30:03 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/and_a_nested_association_on_the_associated_mapping/recursively_builds_all_associations.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/and_a_nested_association_on_the_associated_mapping/recursively_builds_all_associations.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429212359162","token_type":"Bearer","instance_url":"https://<host>","signature":"GigH5zHmZ1IsG+SaU0QdxmWhrvcKdrCm9X2rf1EkiwM=","access_token":"00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:25:58 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002JQEpAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002JQEpAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:00 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002JQEpAAO"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=2/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LoG1AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LoG1AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:01 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"CustomObject__c":"a001a000001LoG1AAK"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=2/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000hKfnAAE","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:02 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002JQEpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002JQEpAAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -201,12 +201,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002JQEpAAO"},"Id":"0031a000002JQEpAAO","SystemModstamp":"2015-04-16T19:26:00.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO"},"Id":"0031a000002JQEpAAO","SystemModstamp":"2015-04-16T19:26:00.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:03 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002JQEpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002JQEpAAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -239,12 +239,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LoG1AAK"},"Id":"a001a000001LoG1AAK","SystemModstamp":"2015-04-16T19:26:01.000+0000","Name":"a001a000001LoG1","Example_Field__c":null,"Friend__c":"0031a000002JQEpAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK"},"Id":"a001a000001LoG1AAK","SystemModstamp":"2015-04-16T19:26:01.000+0000","Name":"a001a000001LoG1","Example_Field__c":null,"Friend__c":"0031a000002JQEpAAO"}]}'
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:04 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LoG1AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LoG1AAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -277,12 +277,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"},"Id":"a011a000000hKfnAAE","SystemModstamp":"2015-04-16T19:26:02.000+0000","Name":"a011a000000hKfn","CustomObject__c":"a001a000001LoG1AAK"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"},"Id":"a011a000000hKfnAAE","SystemModstamp":"2015-04-16T19:26:02.000+0000","Name":"a011a000000hKfn","CustomObject__c":"a001a000001LoG1AAK"}]}'
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:05 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002JQEpAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -312,11 +312,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LoG1AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -346,11 +346,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:08 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -384,6 +384,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Thu, 16 Apr 2015 19:26:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428694613574","token_type":"Bearer","instance_url":"https://<host>","signature":"kgBP47lDsnoj+9xAXQq93nEJXbBT/5IPiHiIdQBA9W4=","access_token":"00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:53 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=63/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001yUpDAAU"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001yUpDAAU","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001yUpDAAU"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=63/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXL8AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXL8AAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yUpDAAU%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yUpDAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000001yUpDAAU"},"Id":"0031a000001yUpDAAU","SystemModstamp":"2015-04-10T19:36:53.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU"},"Id":"0031a000001yUpDAAU","SystemModstamp":"2015-04-10T19:36:53.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yUpDAAU%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yUpDAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXL8AAO"},"Id":"a001a000001LXL8AAO","SystemModstamp":"2015-04-10T19:36:54.000+0000","Name":"a001a000001LXL8","Example_Field__c":null,"Friend__c":"0031a000001yUpDAAU"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO"},"Id":"a001a000001LXL8AAO","SystemModstamp":"2015-04-10T19:36:54.000+0000","Name":"a001a000001LXL8","Example_Field__c":null,"Friend__c":"0031a000001yUpDAAU"}]}'
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001yUpDAAU
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:55 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXL8AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 19:36:55 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557345288","token_type":"Bearer","instance_url":"https://<host>","signature":"KWVtlhIqzN6OZ3uEXDa7ZakPVzRL4UeHWNXC7QKJacs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:15:45 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002bvGPAAY","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:15:46 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002bvGPAAY%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002bvGPAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,12 +117,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY"},"Id":"0031a000002bvGPAAY","SystemModstamp":"2015-04-20T19:15:46.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY"},"Id":"0031a000002bvGPAAY","SystemModstamp":"2015-04-20T19:15:46.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:15:47 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002bvGPAAY%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002bvGPAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -156,11 +156,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:15:49 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002bvGPAAY
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -190,6 +190,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 20 Apr 2015 19:15:50 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430498002630","token_type":"Bearer","instance_url":"https://<host>","signature":"Z6A0wnihwjoySQ2kx85fiWIU125nofxKEitXsJVPx+I=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:22 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=13/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002jr5tAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002jr5tAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:23 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002jr5tAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=12/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP7AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001TuP7AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:23 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5tAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5tAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002jr5tAAA"},"Id":"0031a000002jr5tAAA","SystemModstamp":"2015-05-01T16:33:22.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA"},"Id":"0031a000002jr5tAAA","SystemModstamp":"2015-05-01T16:33:22.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:23 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5tAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5tAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP7AAK"},"Id":"a001a000001TuP7AAK","SystemModstamp":"2015-05-01T16:33:23.000+0000","Name":"a001a000001TuP7","Example_Field__c":null,"Friend__c":"0031a000002jr5tAAA"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK"},"Id":"a001a000001TuP7AAK","SystemModstamp":"2015-05-01T16:33:23.000+0000","Name":"a001a000001TuP7","Example_Field__c":null,"Friend__c":"0031a000002jr5tAAA"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:23 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002jr5tAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:24 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP7AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:24 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430497997739","token_type":"Bearer","instance_url":"https://<host>","signature":"f4tQcugKKSE9kjNZgHUkr/ZXGP27pEKiZGfEskeGWgY=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:18 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=11/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000002jr5oAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000002jr5oAAA","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:18 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000002jr5oAAA"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=11/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP2AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001TuP2AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5oAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5oAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000002jr5oAAA"},"Id":"0031a000002jr5oAAA","SystemModstamp":"2015-05-01T16:33:18.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA"},"Id":"0031a000002jr5oAAA","SystemModstamp":"2015-05-01T16:33:18.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5oAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5oAAA%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP2AAK"},"Id":"a001a000001TuP2AAK","SystemModstamp":"2015-05-01T16:33:18.000+0000","Name":"a001a000001TuP2","Example_Field__c":null,"Friend__c":"0031a000002jr5oAAA"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK"},"Id":"a001a000001TuP2AAK","SystemModstamp":"2015-05-01T16:33:18.000+0000","Name":"a001a000001TuP2","Example_Field__c":null,"Friend__c":"0031a000002jr5oAAA"}]}'
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000002jr5oAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001TuP2AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 01 May 2015 16:33:19 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460626374","token_type":"Bearer","instance_url":"https://<host>","signature":"1Zzf/BDRxmeaZ/+eIrifZJcG35w/MfK2z4CME5hYJa8=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:06 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003Gm5IAAS"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003Gm5IAAS","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:08 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003Gm5IAAS"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=2/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKK8AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK8AAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZKK8AAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:09 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003Gm5IAAS%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003Gm5IAAS%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000003Gm5IAAS"},"Id":"0031a000003Gm5IAAS","SystemModstamp":"2015-05-12T19:57:07.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS"},"Id":"0031a000003Gm5IAAS","SystemModstamp":"2015-05-12T19:57:07.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:10 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003Gm5IAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS
     body:
       encoding: US-ASCII
       string: ''
@@ -194,11 +194,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZKK8AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK8AAO
     body:
       encoding: US-ASCII
       string: ''
@@ -228,6 +228,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Tue, 12 May 2015 19:57:12 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715540708","token_type":"Bearer","instance_url":"https://<host>","signature":"br3UtG9nUBftzMR/OwfVXhT7UyMZMSzwe1iMucUTqME=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:41 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=138/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001yZNRAA2"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001yZNRAA2","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:43 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001yZNRAA2"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=138/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgjAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgjAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:44 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNRAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNRAA2%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000001yZNRAA2"},"Id":"0031a000001yZNRAA2","SystemModstamp":"2015-04-11T01:25:41.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2"},"Id":"0031a000001yZNRAA2","SystemModstamp":"2015-04-11T01:25:41.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:45 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNRAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNRAA2%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgjAAG"},"Id":"a001a000001LXgjAAG","SystemModstamp":"2015-04-11T01:25:44.000+0000","Name":"a001a000001LXgj","Example_Field__c":null,"Friend__c":"0031a000001yZNRAA2"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG"},"Id":"a001a000001LXgjAAG","SystemModstamp":"2015-04-11T01:25:44.000+0000","Name":"a001a000001LXgj","Example_Field__c":null,"Friend__c":"0031a000001yZNRAA2"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:46 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001yZNRAA2
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:47 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgjAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:48 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715530373","token_type":"Bearer","instance_url":"https://<host>","signature":"fO3Z7pIm/ub1DYu2QTcZquDZczorZ6l9epcuSgkv39U=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:30 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=138/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000001yZNMAA2"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000001yZNMAA2","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:31 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000001yZNMAA2"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=138/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgBAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgBAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:33 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNMAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNMAA2%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000001yZNMAA2"},"Id":"0031a000001yZNMAA2","SystemModstamp":"2015-04-11T01:25:31.000+0000","Email":"somebody@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2"},"Id":"0031a000001yZNMAA2","SystemModstamp":"2015-04-11T01:25:31.000+0000","Email":"somebody@example.com"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:35 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNMAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNMAA2%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgBAAW"},"Id":"a001a000001LXgBAAW","SystemModstamp":"2015-04-11T01:25:32.000+0000","Name":"a001a000001LXgB","Example_Field__c":null,"Friend__c":"0031a000001yZNMAA2"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW"},"Id":"a001a000001LXgBAAW","SystemModstamp":"2015-04-11T01:25:32.000+0000","Name":"a001a000001LXgB","Example_Field__c":null,"Friend__c":"0031a000001yZNMAA2"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:36 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000001yZNMAA2
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:37 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgBAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 01:25:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_Salesforce_association_is_out_of_date/updates_the_association_ID_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_Salesforce_association_is_out_of_date/updates_the_association_ID_in_Salesforce.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652877981","token_type":"Bearer","instance_url":"https://<host>","signature":"ihKlEx9EBOiOV8CEtkA0CyhVL84Jph0O4wgSR/kBtNk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:17 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=710/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003QISaAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISaAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003QISaAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:19 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003QISaAAO"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=709/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoEKAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:20 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody+else@example.com","LastName":"Somebody"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=710/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003QISfAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISfAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003QISfAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -201,12 +201,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:20.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISaAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:20.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISaAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:22 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -254,12 +254,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:23 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003QISfAAO"}'
@@ -291,11 +291,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:24 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEKAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEKAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -328,12 +328,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:24.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISfAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:24.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISfAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:25 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEKAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEKAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -366,12 +366,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:24.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISfAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0"},"Id":"a001a000001ZoEKAA0","SystemModstamp":"2015-05-15T01:21:24.000+0000","Name":"a001a000001ZoEK","Example_Field__c":null,"Friend__c":"0031a000003QISfAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:26 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003QISaAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISaAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -401,11 +401,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:27 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEKAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEKAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -435,11 +435,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003QISfAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISfAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -469,6 +469,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:29 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
+++ b/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652895803","token_type":"Bearer","instance_url":"https://<host>","signature":"yr5PJJM+uMppHWQ3IDul6FOK9ofJZTvM750pL/4ajSc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:35 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=718/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003QISkAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISkAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003QISkAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:36 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003QISkAAO"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=719/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoEUAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:37 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/Contact
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact
     body:
       encoding: UTF-8
       string: '{"Email":"somebody+else@example.com","LastName":"Somebody"}'
@@ -156,7 +156,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=722/15000
       Location:
-      - "/services/data/v26.0/sobjects/Contact/0031a000003QISpAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -164,11 +164,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"0031a000003QISpAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:38 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -201,12 +201,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:37.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISkAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:37.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISkAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:40 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -254,12 +254,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:41 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0
     body:
       encoding: UTF-8
       string: '{"Friend__c":"0031a000003QISpAAO"}'
@@ -291,11 +291,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:42 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -328,12 +328,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:43 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003QISpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003QISpAAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -366,12 +366,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/v26.0/sobjects/Contact/0031a000003QISpAAO"},"Id":"0031a000003QISpAAO","SystemModstamp":"2015-05-15T01:21:38.000+0000","Email":"somebody+else@example.com"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO"},"Id":"0031a000003QISpAAO","SystemModstamp":"2015-05-15T01:21:38.000+0000","Email":"somebody+else@example.com"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:44 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -404,12 +404,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:45 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003QISkAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISkAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -439,11 +439,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:46 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEUAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -473,11 +473,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:47 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/Contact/0031a000003QISpAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -507,6 +507,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:48 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_mapping_has_no_conditions/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_mapping_has_no_conditions/does_not_drop_the_synchronized_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652737381","token_type":"Bearer","instance_url":"https://<host>","signature":"eDi+FfWSG5svT9zP9racSdUlz4GQ3ZX37gNEFN5JYyk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:57 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
@@ -73,7 +73,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=624/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCiAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCiAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -81,11 +81,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoCiAAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:58 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCiAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCiAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -115,6 +115,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:59 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/for_a_non-Passive_strategy/drops_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/for_a_non-Passive_strategy/drops_the_synchronized_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652890698","token_type":"Bearer","instance_url":"https://<host>","signature":"0evU70RDGPagRqFniwNzBo1tfyh5vTuYv+0/JBWjpuk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:30 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
@@ -73,7 +73,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=716/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEPAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -81,11 +81,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoEPAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:31 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -118,14 +118,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEPAA0"},"Id":"a001a000001ZoEPAA0","SystemModstamp":"2015-05-15T01:21:31.000+0000","Name":"Are
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0"},"Id":"a001a000001ZoEPAA0","SystemModstamp":"2015-05-15T01:21:31.000+0000","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,11 +159,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:33 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEPAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -193,6 +193,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:21:34 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431653647956","token_type":"Bearer","instance_url":"https://<host>","signature":"0Y5hzj5yAfpvGVh+sdgK56/XvRhuAg1oyXBywP0nOwE=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:34:07 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
@@ -73,7 +73,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=806/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEoAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -81,11 +81,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoEoAAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:34:08 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -118,14 +118,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:34:10 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -158,14 +158,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:34:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEoAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -195,6 +195,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:34:12 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313624267","token_type":"Bearer","instance_url":"https://<host>","signature":"ABLounL9O5kFDJ9y/g/l4dLcm/HQOU8UIF9L3wpVmng=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:04 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=15/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGf9AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LGf9AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:05 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGf9AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGf9AAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:06 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:06Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:06Z
     body:
       encoding: US-ASCII
       string: ''
@@ -156,13 +156,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGf9AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -192,6 +192,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313630193","token_type":"Bearer","instance_url":"https://<host>","signature":"ApVLPX1o4/XFwiO/5YCw9BePXEF1eqtQcn5fdHsn9cI=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:10 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=15/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGfEAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LGfEAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:11 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGfEAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGfEAAW%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:12 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:12Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:12Z
     body:
       encoding: US-ASCII
       string: ''
@@ -156,13 +156,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:13 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGfEAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -192,6 +192,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313635415","token_type":"Bearer","instance_url":"https://<host>","signature":"qgEz8rnSJoiUzNODq0gJyMJXLTeQ+pjzTyA1BwJ1Nq8=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:15 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:14Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:14Z
     body:
       encoding: US-ASCII
       string: ''
@@ -76,6 +76,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 09:47:16 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_a_Passive_strategy/does_not_create_a_database_record.yml
+++ b/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_a_Passive_strategy/does_not_create_a_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428526407882","token_type":"Bearer","instance_url":"https://<host>","signature":"b8JiQgpUdbWK4ZF5QL688+niNH2pYF3BCX6iynboWVI=","access_token":"00D1a000000H3O9!AQ4AQNyTp4z9oP2.J3Cn7NYTEhEEQDKps55QWmUhH0v3eAk6P1DoAUmVHKUnCITNabWF1iOMeT46TMEQTZdyM7pnT5JNIYfj"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:26 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=16/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNKUAA4"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKUAA4"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LNKUAA4","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:27 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNKUAA4
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKUAA4
     body:
       encoding: US-ASCII
       string: ''
@@ -114,6 +114,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_an_Always_strategy/creates_a_matching_database_record.yml
+++ b/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_an_Always_strategy/creates_a_matching_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428526409339","token_type":"Bearer","instance_url":"https://<host>","signature":"EkDl2eLtEFsBSHRtR+7FoXVgwtAsCzKztj+g9CCKYM4=","access_token":"00D1a000000H3O9!AQ4AQNyTp4z9oP2.J3Cn7NYTEhEEQDKps55QWmUhH0v3eAk6P1DoAUmVHKUnCITNabWF1iOMeT46TMEQTZdyM7pnT5JNIYfj"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:28 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=16/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNKZAA4"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKZAA4"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LNKZAA4","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -117,14 +117,14 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
-        object","Example_Field__c":"Some sample text"},{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNKZAA4"},"Id":"a001a000001LNKZAA4","SystemModstamp":"2015-04-08T20:53:29.000+0000","Name":"Custom
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNK5AAO"},"Id":"a001a000001LNK5AAO","SystemModstamp":"2015-04-08T20:49:02.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKZAA4"},"Id":"a001a000001LNKZAA4","SystemModstamp":"2015-04-08T20:53:29.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LNKZAA4
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKZAA4
     body:
       encoding: US-ASCII
       string: ''
@@ -154,6 +154,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 20:53:29 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_database_record/for_an_Always_strategy/populates_Salesforce_with_the_new_record.yml
+++ b/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_database_record/for_an_Always_strategy/populates_Salesforce_with_the_new_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431654460979","token_type":"Bearer","instance_url":"https://<host>","signature":"/pcrxVbljG/4hKqmruGYfY8UiObCMPYIx3CgyVTV2Wk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:40 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -76,11 +76,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:42 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -128,12 +128,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:43 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -163,7 +163,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=812/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF8AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -171,11 +171,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoF8AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:44 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -208,13 +208,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:45 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -247,13 +247,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:46 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF8AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -283,6 +283,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:47 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_a_matching_database_record_exists/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_a_matching_database_record_exists/returns_true.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428332485560","token_type":"Bearer","instance_url":"https://<host>","signature":"GBS/8ndYpWxyywchO4vevnh1DcQqCs1JQ+G8a/Ju8T4=","access_token":"00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:25 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=25/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpnAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LGpnAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpnAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpnAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpnAAG"},"Id":"a001a000001LGpnAAG","SystemModstamp":"2015-04-06T15:01:27.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG"},"Id":"a001a000001LGpnAAG","SystemModstamp":"2015-04-06T15:01:27.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpnAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:31 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_no_matching_database_record_exists/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_no_matching_database_record_exists/returns_false.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428332480120","token_type":"Bearer","instance_url":"https://<host>","signature":"EUwqb7x31VJ+yJ0lgsC7JwgnXdSItzgBAL8Kos1gDnQ=","access_token":"00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil"}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:20 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=24/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpiAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LGpiAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpiAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpiAAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpiAAG"},"Id":"a001a000001LGpiAAG","SystemModstamp":"2015-04-06T15:01:21.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG"},"Id":"a001a000001LGpiAAG","SystemModstamp":"2015-04-06T15:01:21.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:23 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LGpiAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Mon, 06 Apr 2015 15:01:24 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_local_record_with_the_passed_attributes.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_local_record_with_the_passed_attributes.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652676216","token_type":"Bearer","instance_url":"https://<host>","signature":"QUIZ3gZogRPXpwbGfrjTuY4Gqojjf3jw7vDg9lqABuo=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:17:56 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=561/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoC9AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoC9AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:17:57 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoC9AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoC9AAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoC9AAK"},"Id":"a001a000001ZoC9AAK","SystemModstamp":"2015-05-15T01:17:57.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK"},"Id":"a001a000001ZoC9AAK","SystemModstamp":"2015-05-15T01:17:57.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:17:58 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:17:59 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoC9AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK
     body:
       encoding: UTF-8
       string: '{"Example_Field__c":"Some new text"}'
@@ -208,11 +208,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoC9AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -242,6 +242,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:01 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_record_in_Salesforce_with_the_passed_attributes.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_record_in_Salesforce_with_the_passed_attributes.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652682452","token_type":"Bearer","instance_url":"https://<host>","signature":"Qy102BJP9bM487axxMTKz9bQqdSZE51Y979XJlgdJuc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:02 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=563/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCEAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoCEAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:03 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:03.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:03.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:04 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:05 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCEAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0
     body:
       encoding: UTF-8
       string: '{"Example_Field__c":"Some new text"}'
@@ -208,11 +208,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:06 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -245,13 +245,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:06.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:06.000+0000","Name":"Sample
         object","Example_Field__c":"Some new text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCEAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -281,6 +281,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:08 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_all/returns_a_list_of_the_existing_records_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_all/returns_a_list_of_the_existing_records_in_Salesforce.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910168476","token_type":"Bearer","instance_url":"https://<host>","signature":"NrGCnWPtuW3F1C8VyTV7HxO5FJosOMjVa/Mp89FnAAE=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:42:48 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=11/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFfsAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LFfsAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:42:49 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFfsAAG"},"Id":"a001a000001LFfsAAG","SystemModstamp":"2015-04-01T17:42:49.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG"},"Id":"a001a000001LFfsAAG","SystemModstamp":"2015-04-01T17:42:49.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:42:50 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFfsAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:42:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/creates_a_record_in_Salesforce_from_the_passed_database_record_s_attributes.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/creates_a_record_in_Salesforce_from_the_passed_database_record_s_attributes.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431654444927","token_type":"Bearer","instance_url":"https://<host>","signature":"vgZH4Yh+PEwukf4RZ1+W7FWmJKqdoQg0Og0tHYyWy1o=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:24 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -90,12 +90,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:26 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Something","Example_Field__c":"Something else"}'
@@ -125,7 +125,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=810/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEyAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEyAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -133,11 +133,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoEyAAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEyAAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEyAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -170,13 +170,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEyAAK"},"Id":"a001a000001ZoEyAAK","SystemModstamp":"2015-05-15T01:47:27.000+0000","Name":"Something","Example_Field__c":"Something
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEyAAK"},"Id":"a001a000001ZoEyAAK","SystemModstamp":"2015-05-15T01:47:27.000+0000","Name":"Something","Example_Field__c":"Something
         else"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoEyAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEyAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -206,6 +206,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:29 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/updates_the_database_record_with_the_Salesforce_record_s_ID.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/updates_the_database_record_with_the_Salesforce_record_s_ID.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431654450580","token_type":"Bearer","instance_url":"https://<host>","signature":"cZdZrQXtuULSChiTBZnelwS3jngapPntG4i3duMQyAc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:30 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -90,12 +90,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:32 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Something","Example_Field__c":"Something else"}'
@@ -125,7 +125,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=810/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF3AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -133,11 +133,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoF3AAK","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:33 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF3AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF3AAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -170,13 +170,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF3AAK"},"Id":"a001a000001ZoF3AAK","SystemModstamp":"2015-05-15T01:47:33.000+0000","Name":"Something","Example_Field__c":"Something
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK"},"Id":"a001a000001ZoF3AAK","SystemModstamp":"2015-05-15T01:47:33.000+0000","Name":"Something","Example_Field__c":"Something
         else"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:34 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoF3AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -206,6 +206,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:47:35 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/finds_existing_records_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/finds_existing_records_in_Salesforce.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427365205725","token_type":"Bearer","instance_url":"https://<host>","signature":"WPsgaBgCRYGOEsFjS+M6yxlxgnbi9SoEZQtDGGzQFC0=","access_token":"00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:05 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=3/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001J1AWAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001J1AWAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:06 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001J1AWAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001J1AWAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001J1AWAA0"},"Id":"a001a000001J1AWAA0","SystemModstamp":"2015-03-26T10:20:06.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0"},"Id":"a001a000001J1AWAA0","SystemModstamp":"2015-03-26T10:20:06.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:08 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001J1AWAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_does_not_meet_the_conditions/does_not_find_the_record.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_does_not_meet_the_conditions/does_not_find_the_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910682943","token_type":"Bearer","instance_url":"https://<host>","signature":"XV2VCZfDmhSb6On2Br5cxsAz/NvNH3JlkOdbLX/clPY=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:23 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Visible__c":false}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=17/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFgMAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgMAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LFgMAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:24 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgMAAW%27%20and%20Visible__c%20=%20TRUE
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgMAAW%27%20and%20Visible__c%20=%20TRUE
     body:
       encoding: US-ASCII
       string: ''
@@ -118,11 +118,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:25 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFgMAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgMAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -152,6 +152,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:26 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_meets_the_conditions/finds_the_record.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_meets_the_conditions/finds_the_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910678934","token_type":"Bearer","instance_url":"https://<host>","signature":"r7U6IsW9cCkVABj4E879KcDbgJZSkrit4swb8PBuwtw=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:19 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=17/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFgHAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LFgHAAW","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:20 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgHAAW%27%20and%20Visible__c%20=%20TRUE
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgHAAW%27%20and%20Visible__c%20=%20TRUE
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFgHAAW"},"Id":"a001a000001LFgHAAW","SystemModstamp":"2015-04-01T17:51:19.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW"},"Id":"a001a000001LFgHAAW","SystemModstamp":"2015-04-01T17:51:19.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:21 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LFgHAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 01 Apr 2015 17:51:22 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/returns_nil_when_no_matching_record_exists.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/returns_nil_when_no_matching_record_exists.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427365210282","token_type":"Bearer","instance_url":"https://<host>","signature":"1SLB9/QWDmq3AVQgeB8YKrzTdsqbLN8vSCZi8+bmhN0=","access_token":"00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:10 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001E1vFAKE%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001E1vFAKE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -76,6 +76,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Mar 2015 10:20:11 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/wants_to_build_a_new_matching_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/wants_to_build_a_new_matching_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428513920164","token_type":"Bearer","instance_url":"https://<host>","signature":"+9Ohy1Rt/hV2LV72iFHN4G0osOsG5BWr/EnsA2it878=","access_token":"00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs9AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LMs9AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs9AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs9AAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs9AAG"},"Id":"a001a000001LMs9AAG","SystemModstamp":"2015-04-08T17:25:20.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG"},"Id":"a001a000001LMs9AAG","SystemModstamp":"2015-04-08T17:25:20.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs9AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/with_a_corresponding_database_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/with_a_corresponding_database_record/does_not_want_to_build_a_new_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428513917270","token_type":"Bearer","instance_url":"https://<host>","signature":"EQGJyzSNyv8NhiCakDKNBRYnVOwnkS5/GgopPeymCdM=","access_token":"00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=1/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs4AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LMs4AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs4AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs4AAG%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs4AAG"},"Id":"a001a000001LMs4AAG","SystemModstamp":"2015-04-08T17:25:17.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG"},"Id":"a001a000001LMs4AAG","SystemModstamp":"2015-04-08T17:25:17.000+0000","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LMs4AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -153,6 +153,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 08 Apr 2015 17:25:17 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_a_synchronized_association_record/wants_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_a_synchronized_association_record/wants_to_build_a_new_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734569662","token_type":"Bearer","instance_url":"https://<host>","signature":"9ywQmIx1Es8WNVEkdv039RH5e4G8DGM53aUnGnPNLcA=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:50 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=153/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgaAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgaAAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXgaAAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:51 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"CustomObject__c":"a001a000001LXgaAAG"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=153/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gyxHAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:52 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:53 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXgaAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgaAAG
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:56 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -270,6 +270,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:58 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_an_existing_database_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_an_existing_database_record/does_not_want_to_build_a_new_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734589061","token_type":"Bearer","instance_url":"https://<host>","signature":"m7X5wKIMbwHnUlVdcdtxbIwCECW4Yq8Q91BjPfqF68g=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:09 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=154/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXq7AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq7AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXq7AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:10 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"CustomObject__c":"a001a000001LXq7AAG"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=154/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gyxRAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:11 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxRAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxRAAQ%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"},"Id":"a011a000000gyxRAAQ","SystemModstamp":"2015-04-11T06:43:11.000+0000","Name":"a011a000000gyxR","CustomObject__c":"a001a000001LXq7AAG"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"},"Id":"a011a000000gyxRAAQ","SystemModstamp":"2015-04-11T06:43:11.000+0000","Name":"a011a000000gyxR","CustomObject__c":"a001a000001LXq7AAG"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:12 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXq7AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq7AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -194,11 +194,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:13 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -232,6 +232,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:15 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_no_synchronized_association_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_no_synchronized_association_record/does_not_want_to_build_a_new_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734579132","token_type":"Bearer","instance_url":"https://<host>","signature":"22v+bPU50gx+t0KAwCUnZYB07Lyh/CzrwLhWUeAOwQs=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:42:59 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Sample object"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=153/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXq2AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq2AAG"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXq2AAG","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:00 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
       string: '{"CustomObject__c":"a001a000001LXq2AAG"}'
@@ -114,7 +114,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=153/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -122,11 +122,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a011a000000gyxMAAQ","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:01 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
     body:
       encoding: US-ASCII
       string: ''
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:02 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
     body:
       encoding: US-ASCII
       string: ''
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
-    http_version: 
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:04 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXq2AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq2AAG
     body:
       encoding: US-ASCII
       string: ''
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:05 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ
     body:
       encoding: US-ASCII
       string: ''
@@ -270,6 +270,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version: 
+    http_version:
   recorded_at: Sat, 11 Apr 2015 06:43:06 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_database_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652697454","token_type":"Bearer","instance_url":"https://<host>","signature":"IGzFX5UxywYL5AYcXcaWnSqrk/eM5WjIUh/iQvFsr58=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:17 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=578/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCOAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoCOAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCOAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCOAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCOAA0"},"Id":"a001a000001ZoCOAA0","SystemModstamp":"2015-05-15T01:18:18.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0"},"Id":"a001a000001ZoCOAA0","SystemModstamp":"2015-05-15T01:18:18.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:19 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:20 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCOAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0
     body:
       encoding: UTF-8
       string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
@@ -208,11 +208,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:21 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCOAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -242,6 +242,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:22 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_salesforce_record.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652704097","token_type":"Bearer","instance_url":"https://<host>","signature":"nXpmcIeEZIsN2++65pm8yRR9GhzJ5rvZFWHa8lGdtaE=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:24 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=590/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCTAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001ZoCTAA0","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:25 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:25.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:25.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:26 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/describe
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/v26.0/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/v26.0/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/v26.0/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version: 
+    http_version:
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
   recorded_at: Fri, 15 May 2015 01:18:27 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCTAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0
     body:
       encoding: UTF-8
       string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
@@ -208,11 +208,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:29 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
     body:
       encoding: US-ASCII
       string: ''
@@ -245,13 +245,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:29.000+0000","Name":"Some
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:29.000+0000","Name":"Some
         new name","Example_Field__c":"New sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:30 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001ZoCTAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -281,6 +281,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 15 May 2015 01:18:32 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_no_associated_database_record/does_nothing_for_this_specific_mapping.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_no_associated_database_record/does_nothing_for_this_specific_mapping.yml
@@ -38,11 +38,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428689765521","token_type":"Bearer","instance_url":"https://<host>","signature":"iVn8K79ySw/26GQM8/ZHlQ7tE1l2EUH+WGphHVWkQFg=","access_token":"00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
 - request:
     method: post
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
       string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
@@ -72,7 +72,7 @@ http_interactions:
       Sforce-Limit-Info:
       - api-usage=58/15000
       Location:
-      - "/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXBfAAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -80,11 +80,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"id":"a001a000001LXBfAAO","success":true,"errors":[]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -117,13 +117,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/v26.0/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
     body:
       encoding: US-ASCII
       string: ''
@@ -156,13 +156,13 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 18:16:06 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/v26.0/sobjects/CustomObject__c/a001a000001LXBfAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO
     body:
       encoding: US-ASCII
       string: ''
@@ -192,6 +192,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Fri, 10 Apr 2015 18:16:09 GMT
 recorded_with: VCR 2.9.3

--- a/test/support/vcr.rb
+++ b/test/support/vcr.rb
@@ -18,6 +18,14 @@ VCR.configure do |c|
       CGI.escape(Secrets["client"][secret])
     end
   end
+
+  c.filter_sensitive_data("<api_version>") do
+    api_version = Secrets["client"].fetch("api_version") do
+      Restforce::DB::Configuration::DEFAULT_API_VERSION
+    end
+
+    "v#{api_version}"
+  end
 end
 
 MinitestVcr::Spec.configure!


### PR DESCRIPTION
In order to support querying for recently-deleted records, we need to
bump the API version to 29.0. As an intermediate step (and to get our
VCR cassettes trivially compatible with the version change), we’re 
allowing users to specify an API version in their configuration, and
bumping the default up to our desired version.