### PR TITLE
Fix issues with one-to-many lookups

### DIFF
--- a/lib/restforce/db/associations/base.rb
+++ b/lib/restforce/db/associations/base.rb
@@ -46,11 +46,11 @@ module Restforce
         #
         # Returns a Boolean.
         def synced_for?(instance)
+          association_id = associated_salesforce_id(instance)
+          return false unless association_id
+
           base_class = instance.mapping.database_model
           reflection = base_class.reflect_on_association(name)
-          association_id = associated_salesforce_id(instance)
-
-          return false unless association_id
           reflection.klass.exists?(
             mapping_for(reflection).lookup_column => association_id,
           )
@@ -69,12 +69,12 @@ module Restforce
         # Internal: Get the appropriate Salesforce Lookup ID field for the
         # passed mapping.
         #
-        # mapping         - A Restforce::DB::Mapping.
-        # database_record - An instance of an ActiveRecord::Base subclass.
+        # mapping    - A Restforce::DB::Mapping.
+        # reflection - An ActiveRecord::AssociationReflection.
         #
         # Returns a String or nil.
-        def lookup_field(mapping, database_record)
-          inverse = inverse_association_name(target_reflection(database_record))
+        def lookup_field(mapping, reflection)
+          inverse = inverse_association_name(reflection)
           association = mapping.associations.detect { |a| a.name == inverse }
           return unless association
 

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -78,7 +78,7 @@ module Restforce
         # Returns nothing.
         def for_mappings(database_record)
           Registry[target_class(database_record)].each do |mapping|
-            lookup = lookup_field(mapping, database_record)
+            lookup = lookup_field(mapping, target_reflection(database_record))
             next unless lookup
             yield mapping, lookup
           end

--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -57,15 +57,11 @@ module Restforce
           ids = {}
 
           for_mappings(database_record) do |mapping, lookup|
-            associated = database_record.association(name).reader
-
-            ids[lookup] =
-              if associated
-                # It's possible to define a belongs_to association in a Mapping
-                # for what is actually a one-to-many association on the
-                # ActiveRecord object.
-                Array(associated).first.send(mapping.lookup_column)
-              end
+            # It's possible to define a belongs_to association in a Mapping
+            # for what is actually a one-to-many association on the
+            # ActiveRecord object, so we always treat the result as an Array.
+            associated = Array(database_record.association(name).reader)
+            ids[lookup] = associated.empty? ? nil : associated.first.send(mapping.lookup_column)
           end
 
           ids

--- a/lib/restforce/db/associations/foreign_key.rb
+++ b/lib/restforce/db/associations/foreign_key.rb
@@ -61,11 +61,10 @@ module Restforce
         #
         # Returns a String.
         def associated_salesforce_id(instance)
-          query = "#{lookup} = '#{instance.id}'"
-
           reflection = instance.mapping.database_model.reflect_on_association(name)
           inverse_mapping = mapping_for(reflection)
 
+          query = "#{lookup_field(inverse_mapping, reflection)} = '#{instance.id}'"
           salesforce_instance = inverse_mapping.salesforce_record_type.first(query)
           salesforce_instance.id if salesforce_instance
         end

--- a/lib/restforce/db/associations/has_many.rb
+++ b/lib/restforce/db/associations/has_many.rb
@@ -23,7 +23,8 @@ module Restforce
           @cache = cache
 
           target = target_mapping(database_record)
-          lookup_id = "#{lookup_field(target, database_record)} = '#{salesforce_record.Id}'"
+          reflection = target_reflection(database_record)
+          lookup_id = "#{lookup_field(target, reflection)} = '#{salesforce_record.Id}'"
 
           records = []
           target.salesforce_record_type.all(conditions: lookup_id).each do |instance|

--- a/lib/restforce/db/associations/has_one.rb
+++ b/lib/restforce/db/associations/has_one.rb
@@ -23,7 +23,8 @@ module Restforce
           @cache = cache
 
           target = target_mapping(database_record)
-          query = "#{lookup_field(target, database_record)} = '#{salesforce_record.Id}'"
+          reflection = target_reflection(database_record)
+          query = "#{lookup_field(target, reflection)} = '#{salesforce_record.Id}'"
 
           instance = target.salesforce_record_type.first(query)
           instance ? construct_for(database_record, instance) : []

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_a_nil_lookup_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_a_nil_lookup_value_in_the_hash.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 19 May 2015 21:06:48 GMT
+      Set-Cookie:
+      - BrowserId=ByBZSCL6S7-SC1BiTBWUiw;Path=/;Domain=.salesforce.com;Expires=Sat,
+        18-Jul-2015 21:06:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1432069609059","token_type":"Bearer","instance_url":"https://<host>","signature":"zfbrLMOjqIUvY4r6QBb65KMC5wUj6Z/2Ll6lwfEX9xc=","access_token":"00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh"}'
+    http_version: 
+  recorded_at: Tue, 19 May 2015 21:06:49 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Sample object"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Tue, 19 May 2015 21:06:50 GMT
+      Set-Cookie:
+      - BrowserId=1OdDxkXQRi-VcR2auOFilA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        18-Jul-2015 21:06:50 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=34/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a9cUAAQ"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001a9cUAAQ","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Tue, 19 May 2015 21:06:50 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a9cUAAQ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Tue, 19 May 2015 21:06:51 GMT
+      Set-Cookie:
+      - BrowserId=F2NnH09RSISLTmIFu-lAoA;Path=/;Domain=.salesforce.com;Expires=Sat,
+        18-Jul-2015 21:06:51 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=35/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 19 May 2015 21:06:51 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -60,6 +60,23 @@ describe Restforce::DB::Associations::BelongsTo do
         it "returns a nil lookup value in the hash" do
           expect(association.lookups(object)).to_equal("Friend__c" => nil)
         end
+
+        describe "and the underlying association is one-to-many" do
+          let(:association) { Restforce::DB::Associations::BelongsTo.new(:admirers, through: "Friend__c") }
+          let(:inverse_mapping) do
+            Restforce::DB::Mapping.new(User, "Contact").tap do |map|
+              map.fields = { email: "Email" }
+              map.associations << Restforce::DB::Associations::HasOne.new(
+                :favorite,
+                through: "Friend__c",
+              )
+            end
+          end
+
+          it "still returns a nil lookup value in the hash" do
+            expect(association.lookups(object)).to_equal("Friend__c" => nil)
+          end
+        end
       end
     end
 

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define do
 
   create_table :users do |table|
     table.column :email,           :string
+    table.column :favorite_id,     :integer
     table.column :salesforce_id,   :string
     table.column :synchronized_at, :datetime
     table.timestamps null: false
@@ -44,6 +45,7 @@ end
 class CustomObject < ActiveRecord::Base
 
   belongs_to :user, inverse_of: :custom_object, autosave: true
+  has_many :admirers, class_name: "User", inverse_of: :favorite, foreign_key: :favorite_id
   has_many :details, inverse_of: :custom_object
 
 end
@@ -59,5 +61,6 @@ end
 class User < ActiveRecord::Base
 
   has_one :custom_object, inverse_of: :user
+  belongs_to :favorite, class_name: "CustomObject", inverse_of: :admirers, foreign_key: :favorite_id
 
 end


### PR DESCRIPTION
When fetching our Hash of lookup IDs, we currently break in the case
where we have a BelongsTo association with an underlying one-to-many 
ActiveRecord association which is currently empty. This is a quick bug
fix to address that issue.