### PR TITLE
Create top-level cache for new database records

### DIFF
--- a/lib/restforce/db/record_types/active_record.rb
+++ b/lib/restforce/db/record_types/active_record.rb
@@ -19,7 +19,11 @@ module Restforce
         def create!(from_record)
           record = @record_type.find_or_initialize_by(@mapping.lookup_column => from_record.id)
           record.assign_attributes(@mapping.convert(@record_type, from_record.attributes))
-          associations = @mapping.associations.flat_map { |a| a.build(record, from_record.record) }
+
+          cache = AssociationCache.new(record)
+          associations = @mapping.associations.flat_map do |association|
+            association.build(record, from_record.record, cache)
+          end
 
           record.transaction do
             record.save!


### PR DESCRIPTION
It’s possible for a new database record under construction to have 
several inter-connected association records. In order to ensure that the
records we build maintain consistent references to the same in-memory
objects, we need to initialize our AssociationCache at the top level, 
and manually pass it in to each association’s build invocation.