### PR TITLE
Handle record-specific errors transactionally

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -56,7 +56,7 @@ module Restforce
     class << self
 
       attr_accessor :last_run
-      attr_writer :configuration
+      attr_writer :configuration, :logger
 
     end
 
@@ -65,6 +65,13 @@ module Restforce
     # Returns a Restforce::DB::Configuration instance.
     def self.configuration
       @configuration ||= Configuration.new
+    end
+
+    # Public: Get the current logger for Restforce::DB.
+    #
+    # Returns a Logger instance.
+    def self.logger
+      @logger ||= Logger.new("/dev/null")
     end
 
     # Public: Get a Restforce client based on the currently configured settings.

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -73,6 +73,8 @@ module Restforce
           end
           database_record.save!
         end
+      rescue ActiveRecord::RecordInvalid, Faraday::Error::ClientError => e
+        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 
       # Internal: Get a Hash of associated lookup IDs for the passed database

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -73,7 +73,7 @@ module Restforce
           end
           database_record.save!
         end
-      rescue ActiveRecord::RecordInvalid, Faraday::Error::ClientError => e
+      rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
         DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 

--- a/lib/restforce/db/command.rb
+++ b/lib/restforce/db/command.rb
@@ -57,6 +57,7 @@ module Restforce
         Dir.chdir(Rails.root)
 
         Restforce::DB::Worker.after_fork
+        Restforce::DB.logger = logger
 
         worker = Restforce::DB::Worker.new(options)
         worker.logger = logger

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -42,7 +42,7 @@ module Restforce
       def create_in_database(instance)
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
-      rescue ActiveRecord::RecordInvalid => e
+      rescue ActiveRecord::ActiveRecordError => e
         DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -42,6 +42,8 @@ module Restforce
       def create_in_database(instance)
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
+      rescue ActiveRecord::RecordInvalid => e
+        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 
       # Internal: Attempt to create a partner record in Salesforce for the
@@ -54,6 +56,8 @@ module Restforce
       def create_in_salesforce(instance)
         return if instance.synced?
         @mapping.salesforce_record_type.create!(instance)
+      rescue Faraday::Error::ClientError => e
+        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 
     end

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -55,7 +55,7 @@ module Restforce
         attributes = @mapping.convert(instance.record_type, current_attributes)
 
         instance.update!(attributes)
-      rescue ActiveRecord::RecordInvalid, Faraday::Error::ClientError => e
+      rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
         DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -55,6 +55,8 @@ module Restforce
         attributes = @mapping.convert(instance.record_type, current_attributes)
 
         instance.update!(attributes)
+      rescue ActiveRecord::RecordInvalid, Faraday::Error::ClientError => e
+        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
       end
 
     end

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -186,11 +186,11 @@ module Restforce
         runtime = Benchmark.realtime { yield }
         log format("  COMPLETE after %.4f", runtime)
 
-        return true
+        true
       rescue => e
         error(e)
 
-        return false
+        false
       end
 
       # Internal: Has this worker been instructed to stop?

--- a/test/lib/restforce/db_test.rb
+++ b/test/lib/restforce/db_test.rb
@@ -4,6 +4,20 @@ describe Restforce::DB do
 
   configure!
 
+  describe "#logger" do
+
+    it "defaults to a null logger" do
+      log_device = Restforce::DB.logger.instance_variable_get("@logdev")
+      expect(log_device.dev.path).to_equal "/dev/null"
+    end
+
+    it "allows assignment of a new logger" do
+      logger = Logger.new("/dev/null")
+      Restforce::DB.logger = logger
+      expect(Restforce::DB.logger).to_equal logger
+    end
+  end
+
   describe "#configure" do
 
     it "yields a Configuration" do

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -8,6 +8,7 @@ def configure!
     Restforce::DB::FieldProcessor.reset
     Restforce::DB::Registry.clean!
     Restforce::DB.last_run = nil
+    Restforce::DB.logger = nil
 
     DatabaseCleaner.clean
     Salesforce.clean!


### PR DESCRIPTION
When a single record fails to process within one of our task classes, we
should still continue to process the remaining records for that mapping.

Here, we add task-level exception logging, and rescue out of what are
generally harmless validation errors, to allow the task to continue its
processing for subsequent instances.