### PR TITLE
Synchronize deletion of records from Salesforce

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -4,6 +4,7 @@ require "restforce"
 require "restforce/extensions"
 
 require "restforce/db/version"
+require "restforce/db/client"
 require "restforce/db/configuration"
 require "restforce/db/registry"
 require "restforce/db/strategy"
@@ -78,7 +79,7 @@ module Restforce
     #
     # Returns a Restforce::Data::Client instance.
     def self.client
-      @client ||= Restforce.new(
+      @client ||= DB::Client.new(
         username:       configuration.username,
         password:       configuration.password,
         security_token: configuration.security_token,

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -3,8 +3,8 @@ module Restforce
   module DB
 
     # Restforce::DB::Cleaner is responsible for culling the matching database
-    # records when a Salesforce record has been deleted or otherwise no longer
-    # meets the sync conditions for a mapping.
+    # records when a Salesforce record is no longer available to synchronize
+    # for a specific mapping.
     class Cleaner
 
       # Salesforce can take a few minutes to register record deletion. This

--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -3,8 +3,14 @@ module Restforce
   module DB
 
     # Restforce::DB::Cleaner is responsible for culling the matching database
-    # records when a Salesforce record no longer meets the sync conditions.
+    # records when a Salesforce record has been deleted or otherwise no longer
+    # meets the sync conditions for a mapping.
     class Cleaner
+
+      # Salesforce can take a few minutes to register record deletion. This
+      # buffer gives us a window of time (in seconds) to look back and see
+      # records which may not have been visible in previous runs.
+      DELETION_READ_BUFFER = 3 * 60
 
       # Public: Initialize a Restforce::DB::Cleaner.
       #
@@ -20,11 +26,44 @@ module Restforce
       #
       # Returns nothing.
       def run
+        drop_deleted_records
+        drop_invalid_records
+      end
+
+      private
+
+      # Internal: Destroy any database records corresponding to Salesforce
+      # records which have been deleted within the Salesforce environment.
+      #
+      # Returns nothing.
+      def drop_deleted_records
+        return unless @runner.after
+        @mapping.database_record_type.destroy_all(deleted_salesforce_ids)
+      end
+
+      # Internal: Destroy any database records corresponding to Salesforce
+      # records which have been modified such that they no longer meet the
+      # conditions defined for this mapping.
+      #
+      # Returns nothing.
+      def drop_invalid_records
         return if @mapping.conditions.empty? || @strategy.passive?
         @mapping.database_record_type.destroy_all(invalid_salesforce_ids)
       end
 
-      private
+      # Internal: Get the IDs of records which have been removed from Salesforce
+      # for this mapping within the DELETION_BUFFER for this run.
+      #
+      # Returns an Array of IDs.
+      def deleted_salesforce_ids
+        response = Restforce::DB.client.get_deleted_between(
+          @mapping.salesforce_model,
+          @runner.after - DELETION_READ_BUFFER,
+          @runner.before,
+        )
+
+        response.deletedRecords.map(&:id)
+      end
 
       # Internal: Get the IDs of records which are in the larger collection
       # of Salesforce records, but which do not meet the specific conditions for

--- a/lib/restforce/db/client.rb
+++ b/lib/restforce/db/client.rb
@@ -3,8 +3,8 @@ module Restforce
   module DB
 
     # Restforce::DB::Client is a thin abstraction on top of the default
-    # Restforce::Data::Client class, which adds support for a handful of useful
-    # endpoints not yet supported by the base gem.
+    # Restforce::Data::Client class, which adds support for an API endpoint
+    # not yet supported by the base gem.
     class Client < ::Restforce::Data::Client
 
       # Public: Get a list of Salesforce records which have been deleted between

--- a/lib/restforce/db/client.rb
+++ b/lib/restforce/db/client.rb
@@ -1,0 +1,52 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Client is a thin abstraction on top of the default
+    # Restforce::Data::Client class, which adds support for a handful of useful
+    # endpoints not yet supported by the base gem.
+    class Client < ::Restforce::Data::Client
+
+      # Public: Get a list of Salesforce records which have been deleted between
+      # the specified times.
+      #
+      # sobject    - The Salesforce object type to query against.
+      # start_time - A Time or Time-compatible object indicating the earliest
+      #              time for which to find deleted records.
+      # end_time   - A Time or Time-compatible object indicating the latest time
+      #              for which to find deleted records. Defaults to the current
+      #              time.
+      #
+      # Example
+      #
+      #   Restforce::DB.client.get_deleted_between(
+      #     "CustomObject__c",
+      #     Time.now - 300,
+      #     Time.now,
+      #   )
+      #
+      #   #=> #<Restforce::Mash
+      #          latestDateCovered="2015-05-18T22:31:00.000+0000"
+      #          earliestDateAvailable="2015-04-11T06:44:00.000+0000"
+      #          deletedRecords=[
+      #            #<Restforce::Mash
+      #              deletedDate="2015-05-18T22:31:17.000+0000"
+      #              id="a001a000001a5vOAAQ"
+      #            >
+      #          ]
+      #        >
+      #
+      # Returns a Restforce::Mash with a `deletedRecords` key.
+      def get_deleted_between(sobject, start_time, end_time = Time.now)
+        api_get(
+          "sobjects/#{sobject}/deleted",
+          start: start_time.utc.iso8601,
+          end: end_time.utc.iso8601,
+        ).body
+      end
+
+    end
+
+  end
+
+end

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_has_been_deleted_in_Salesforce/drops_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_has_been_deleted_in_Salesforce/drops_the_synchronized_database_record.yml
@@ -1,0 +1,120 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 20 May 2015 22:04:31 GMT
+      Set-Cookie:
+      - BrowserId=bSV2iUXwSSOWJFCXI7O_RA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        19-Jul-2015 22:04:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1432159471623","token_type":"Bearer","instance_url":"https://<host>","signature":"vlqOCnMqVU2ShrK2bLIsZTK24INW4Z4LpDdILzgxrFs=","access_token":"00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6"}'
+    http_version: 
+  recorded_at: Wed, 20 May 2015 22:04:31 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Are you going to Scarborough Fair?","Example_Field__c":"Parsley,
+        Sage, Rosemary, and Thyme."}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 20 May 2015 22:04:31 GMT
+      Set-Cookie:
+      - BrowserId=iTltKbJMRMS2WMP0BxPVvg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        19-Jul-2015 22:04:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=9/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aHLuAAM"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001aHLuAAM","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Wed, 20 May 2015 22:04:31 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aHLuAAM
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Wed, 20 May 2015 22:04:32 GMT
+      Set-Cookie:
+      - BrowserId=6WNubRIVSxG4Hy8WSNOcaw;Path=/;Domain=.salesforce.com;Expires=Sun,
+        19-Jul-2015 22:04:32 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=9/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 20 May 2015 22:04:32 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/cleaner_test.rb
+++ b/test/lib/restforce/db/cleaner_test.rb
@@ -73,6 +73,28 @@ describe Restforce::DB::Cleaner do
           end
         end
       end
+
+      describe "when the record has been deleted in Salesforce" do
+        let(:runner) { Restforce::DB::Runner.new(0, Time.now - 300) }
+        let(:cleaner) { Restforce::DB::Cleaner.new(mapping, runner) }
+        let(:dummy_response) do
+          Struct.new(:deletedRecords).new([
+            Restforce::Mash.new(id: salesforce_id),
+          ])
+        end
+
+        before do
+          runner.tick!
+        end
+
+        it "drops the synchronized database record" do
+          Restforce::DB::Client.stub_any_instance(:get_deleted_between, dummy_response) do
+            cleaner.run
+          end
+
+          expect(database_model.last).to_be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When a record is deleted from Salesforce, it is maintained for about 15
days in an archive in their system, which we can query on each run. As
we identify new records which have been deleted, we should drop them 
from our system, mirroring the actual state of the data.