### PR TITLE
Distinguish between create- and update-only fields

### DIFF
--- a/lib/restforce/db/record_types/salesforce.rb
+++ b/lib/restforce/db/record_types/salesforce.rb
@@ -17,7 +17,7 @@ module Restforce
         # Returns a Restforce::DB::Instances::Salesforce instance.
         # Raises on any error from Salesforce.
         def create!(from_record)
-          from_attributes = FieldProcessor.new.process(@record_type, from_record.attributes)
+          from_attributes = FieldProcessor.new.process(@record_type, from_record.attributes, :create)
           record_id = DB.client.create!(@record_type, from_attributes)
 
           from_record.update!(@mapping.lookup_column => record_id).after_sync

--- a/test/lib/restforce/db/field_processor_test.rb
+++ b/test/lib/restforce/db/field_processor_test.rb
@@ -9,8 +9,9 @@ describe Restforce::DB::FieldProcessor do
   describe "#process" do
     let(:attributes) do
       {
-        "Name" => "This field can be updated.",
-        "Id"   => "But... but... this field is read-only!",
+        "Creatable"  => "This field is create-only!",
+        "Updateable" => "And... this field is update-only!",
+        "Both"       => "But... this field allows both!",
       }
     end
     let(:dummy_client) do
@@ -21,18 +22,29 @@ describe Restforce::DB::FieldProcessor do
           @already_run = true
 
           Struct.new(:fields).new([
-            { "name" => "Name", "updateable" => true },
-            { "name" => "Id", "updateable" => false },
+            { "name" => "Creatable", "createable" => true, "updateable" => false },
+            { "name" => "Updateable", "createable" => false, "updateable" => true },
+            { "name" => "Both", "createable" => true, "updateable" => true },
           ])
         end
 
       end
     end
 
-    it "removes the read-only fields from the passed attribute Hash" do
+    it "removes the read-only fields from the passed attribute Hash on :create" do
       Restforce::DB.stub(:client, dummy_client) do
-        expect(processor.process("CustomObject__c", attributes)).to_equal(
-          "Name" => attributes["Name"],
+        expect(processor.process("CustomObject__c", attributes, :create)).to_equal(
+          "Creatable" => attributes["Creatable"],
+          "Both"      => attributes["Both"],
+        )
+      end
+    end
+
+    it "removes the read-only fields from the passed attribute Hash on :update" do
+      Restforce::DB.stub(:client, dummy_client) do
+        expect(processor.process("CustomObject__c", attributes, :update)).to_equal(
+          "Updateable" => attributes["Updateable"],
+          "Both"       => attributes["Both"],
         )
       end
     end


### PR DESCRIPTION
Salesforce makes a distinction between fields which can be created and
fields which can be updated, storing the values as two separate
attributes for the field. On initial record construction, we need to be
able to pass all “createable” fields along to prevent validation issues.