### PR TITLE
Add configurable `after_fork` hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: ruby
-rvm:
-  - 2.2.0

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -64,6 +64,7 @@ module Restforce
         :configuration,
         :logger,
         :logger=,
+        :after_fork,
       )
 
     end

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -57,7 +57,14 @@ module Restforce
     class << self
 
       attr_accessor :last_run
-      attr_writer :configuration, :logger
+      attr_writer :configuration
+
+      extend Forwardable
+      def_delegators(
+        :configuration,
+        :logger,
+        :logger=,
+      )
 
     end
 
@@ -66,13 +73,6 @@ module Restforce
     # Returns a Restforce::DB::Configuration instance.
     def self.configuration
       @configuration ||= Configuration.new
-    end
-
-    # Public: Get the current logger for Restforce::DB.
-    #
-    # Returns a Logger instance.
-    def self.logger
-      @logger ||= Logger.new("/dev/null")
     end
 
     # Public: Get a Restforce client based on the currently configured settings.

--- a/lib/restforce/db/command.rb
+++ b/lib/restforce/db/command.rb
@@ -56,8 +56,9 @@ module Restforce
       def run(options = {})
         Dir.chdir(Rails.root)
 
-        Restforce::DB::Worker.after_fork
         Restforce::DB.logger = logger
+        Restforce::DB::Worker.after_fork
+        Restforce::DB.after_fork
 
         worker = Restforce::DB::Worker.new(options)
         worker.logger = logger

--- a/lib/restforce/db/configuration.rb
+++ b/lib/restforce/db/configuration.rb
@@ -21,6 +21,20 @@ module Restforce
         logger
       ))
 
+      # Public: Allow an after_fork callback to be configured or run. Runs the
+      # previously-configured block if called without arguments.
+      #
+      # block - A block of code to execute after process forking.
+      #
+      # Returns nothing.
+      def after_fork(&block)
+        if block_given?
+          @after_fork ||= block
+        else
+          @after_fork.call if @after_fork
+        end
+      end
+
       # Public: Get the configured logger. Returns a null logger if no logger
       # has been configured yet.
       #

--- a/lib/restforce/db/configuration.rb
+++ b/lib/restforce/db/configuration.rb
@@ -18,7 +18,16 @@ module Restforce
         client_secret
         host
         api_version
+        logger
       ))
+
+      # Public: Get the configured logger. Returns a null logger if no logger
+      # has been configured yet.
+      #
+      # Returns a Logger.
+      def logger
+        @logger ||= Logger.new("/dev/null")
+      end
 
       # Public: Parse a supplied YAML file for a set of credentials, and use
       # them to populate the attributes on this configuraton object.

--- a/test/lib/restforce/db/configuration_test.rb
+++ b/test/lib/restforce/db/configuration_test.rb
@@ -8,6 +8,14 @@ describe Restforce::DB::Configuration do
   let(:secrets_file) { File.expand_path("../../../../config/secrets.yml", __FILE__) }
   let(:configuration) { Restforce::DB::Configuration.new }
 
+  describe "#logger" do
+
+    it "defaults to a null logger" do
+      log_device = configuration.logger.instance_variable_get("@logdev")
+      expect(log_device.dev.path).to_equal "/dev/null"
+    end
+  end
+
   describe "#load" do
 
     describe "when all configurations are supplied" do

--- a/test/lib/restforce/db/configuration_test.rb
+++ b/test/lib/restforce/db/configuration_test.rb
@@ -8,6 +8,31 @@ describe Restforce::DB::Configuration do
   let(:secrets_file) { File.expand_path("../../../../config/secrets.yml", __FILE__) }
   let(:configuration) { Restforce::DB::Configuration.new }
 
+  describe "#after_fork" do
+
+    it "does nothing if invoked without a block" do
+      # NOTE: We're asserting that this invocation doesn't raise an error.
+      configuration.after_fork
+    end
+
+    it "does not invoke the block on configuration" do
+      a = 1
+
+      configuration.after_fork { a += 1 }
+
+      expect(a).to_equal 1
+    end
+
+    it "invokes the configured block when called without arguments" do
+      a = 1
+
+      configuration.after_fork { a += 1 }
+      configuration.after_fork
+
+      expect(a).to_equal 2
+    end
+  end
+
   describe "#logger" do
 
     it "defaults to a null logger" do

--- a/test/lib/restforce/db_test.rb
+++ b/test/lib/restforce/db_test.rb
@@ -4,20 +4,6 @@ describe Restforce::DB do
 
   configure!
 
-  describe "#logger" do
-
-    it "defaults to a null logger" do
-      log_device = Restforce::DB.logger.instance_variable_get("@logdev")
-      expect(log_device.dev.path).to_equal "/dev/null"
-    end
-
-    it "allows assignment of a new logger" do
-      logger = Logger.new("/dev/null")
-      Restforce::DB.logger = logger
-      expect(Restforce::DB.logger).to_equal logger
-    end
-  end
-
   describe "#configure" do
 
     it "yields a Configuration" do


### PR DESCRIPTION
In order to run `Restforce::DB`-specific configuration during app initialization, we need a hook for said configuration which will run when the daemon spins up. This PR adds such a hook, and moves some additional configuration functionality into the `Configuration` class where it belongs.