### PR TITLE
Clean invalid records before propagation step

### DIFF
--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -79,8 +79,8 @@ module Restforce
           @changes = Hash.new { |h, k| h[k] = Accumulator.new }
 
           Restforce::DB::Registry.each do |mapping|
-            task("PROPAGATING RECORDS", mapping) { propagate mapping }
             task("CLEANING RECORDS", mapping) { clean mapping }
+            task("PROPAGATING RECORDS", mapping) { propagate mapping }
             task("COLLECTING CHANGES", mapping) { collect mapping }
             task("UPDATING ASSOCIATIONS", mapping) { associate mapping }
           end


### PR DESCRIPTION
Now that we cache our record queries, we run into a problem with record
propagation — namely, we cache the results of our original query _prior_
to adding any new records. Then, when the `Cleaner` runs, the list of 
valid Salesforce IDs (from that cached query) doesn’t have the ID of our
new record, and we immediately remove it.

The solution (without giving up the performance advantages of caching 
our query results) is simply to run our cleanup step before propagating
new records up to Salesforce.