### PR TITLE
Pass errors directly to logger

### DIFF
--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -74,7 +74,7 @@ module Restforce
           database_record.save!
         end
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
-        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
+        DB.logger.error(e)
       end
 
       # Internal: Get a Hash of associated lookup IDs for the passed database

--- a/lib/restforce/db/command.rb
+++ b/lib/restforce/db/command.rb
@@ -118,8 +118,21 @@ module Restforce
       # Returns a Logger.
       def logger
         @logger ||= Logger.new(@options[:logfile]).tap do |logger|
-          logger.formatter = proc do |severity, datetime, _progname, msg|
-            "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{msg}\n"
+          logger.formatter = proc do |severity, datetime, _progname, message|
+            # Implementation taken from Ruby's msg2str.
+            # See: http://apidock.com/ruby/Logger/Formatter/msg2str
+            formatted =
+              case message
+              when ::String
+                message
+              when ::Exception
+                backtrace = message.backtrace || []
+                "#{message.message} (#{message.class})\n#{backtrace.join("\n")}"
+              else
+                message.inspect
+              end
+
+            "#{severity} [#{datetime.strftime('%Y-%m-%d %H:%M:%S')}] #{formatted}\n"
           end
         end
       end

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -43,7 +43,7 @@ module Restforce
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
       rescue ActiveRecord::ActiveRecordError => e
-        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
+        DB.logger.error(e)
       end
 
       # Internal: Attempt to create a partner record in Salesforce for the
@@ -57,7 +57,7 @@ module Restforce
         return if instance.synced?
         @mapping.salesforce_record_type.create!(instance)
       rescue Faraday::Error::ClientError => e
-        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
+        DB.logger.error(e)
       end
 
     end

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -56,7 +56,7 @@ module Restforce
 
         instance.update!(attributes)
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
-        DB.logger.error("#{e.message}\n#{e.backtrace.join("\n")}")
+        DB.logger.error(e)
       end
 
     end

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -220,7 +220,7 @@ module Restforce
       #
       # Returns nothing.
       def error(exception)
-        log "#{exception.message}\n#{exception.backtrace.join("\n")}", :error
+        logger.error(exception)
       end
 
     end


### PR DESCRIPTION
For better compatibility with various exception logging middlewares, we 
want to pass the actual exception object through to the logger, and let
the formatter handle the representation of that object.