### PR TITLE
Pass the Worker object to the configuration hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,11 @@ For additional information and a full set of options, you can run:
 
 #### Configuring the daemon's runtime environment
 
-Restforce::DB allows you to configure up a block of code which will execute when the daemon process forks. In an initializer (or any other piece of code which will run as your application spins up), you can use `config.after_fork` to set up this hook:
+Restforce::DB allows you to configure a block of code which will execute before the daemon process's polling loop initiates. In an initializer (or any other piece of code which will run as your application spins up), you can use `config.before` to set up this hook:
 
 ```ruby
 Restforce::DB.configure do |config|
-  config.after_fork { ActiveRecord::Base.logger = nil }
+  config.before { |_worker| ActiveRecord::Base.logger = nil }
 end
 ```
 

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -64,7 +64,7 @@ module Restforce
         :configuration,
         :logger,
         :logger=,
-        :after_fork,
+        :before,
       )
 
     end

--- a/lib/restforce/db/command.rb
+++ b/lib/restforce/db/command.rb
@@ -56,19 +56,17 @@ module Restforce
       def run(options = {})
         Dir.chdir(Rails.root)
 
-        Restforce::DB.logger = logger
-
         # This hook comes from the FileDaemon module, and keeps file descriptors
         # opened after the process forks.
         Restforce::DB::Worker.after_fork
 
-        # This hook can be configured in an initializer, and allows changes to
-        # the runtime environment after the process forks.
-        Restforce::DB.after_fork
-
         worker = Restforce::DB::Worker.new(options)
         worker.logger = logger
         worker.tracker = tracker
+
+        # This hook can be configured in an initializer, and allows changes to
+        # the worker before the daemon loop begins processing.
+        Restforce::DB.before(worker)
 
         worker.start
       rescue => e

--- a/lib/restforce/db/configuration.rb
+++ b/lib/restforce/db/configuration.rb
@@ -21,17 +21,19 @@ module Restforce
         logger
       ))
 
-      # Public: Allow an after_fork callback to be configured or run. Runs the
-      # previously-configured block if called without arguments.
+      # Public: Allow a `before` callback to be configured or run. Runs the
+      # previously-configured block with any passed objects if called without a
+      # block.
       #
+      # args  - An arbitrary collection of arguments to pass to the hook.
       # block - A block of code to execute after process forking.
       #
       # Returns nothing.
-      def after_fork(&block)
+      def before(*args, &block)
         if block_given?
-          @after_fork ||= block
+          @before_hook = block
         else
-          @after_fork.call if @after_fork
+          @before_hook.call(*args) if @before_hook
         end
       end
 

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -37,6 +37,8 @@ module Restforce
       #
       # Returns nothing.
       def start
+        DB.configure { |config| config.logger = logger }
+
         trap_signals
 
         loop do

--- a/test/lib/restforce/db/configuration_test.rb
+++ b/test/lib/restforce/db/configuration_test.rb
@@ -8,28 +8,37 @@ describe Restforce::DB::Configuration do
   let(:secrets_file) { File.expand_path("../../../../config/secrets.yml", __FILE__) }
   let(:configuration) { Restforce::DB::Configuration.new }
 
-  describe "#after_fork" do
+  describe "#before" do
 
     it "does nothing if invoked without a block" do
       # NOTE: We're asserting that this invocation doesn't raise an error.
-      configuration.after_fork
+      configuration.before
     end
 
-    it "does not invoke the block on configuration" do
+    it "does not invoke the hook on configuration" do
       a = 1
 
-      configuration.after_fork { a += 1 }
+      configuration.before { a += 1 }
 
       expect(a).to_equal 1
     end
 
-    it "invokes the configured block when called without arguments" do
+    it "invokes the configured hook when called without a block" do
       a = 1
 
-      configuration.after_fork { a += 1 }
-      configuration.after_fork
+      configuration.before { a += 1 }
+      configuration.before
 
       expect(a).to_equal 2
+    end
+
+    it "invokes the configured hook with passed arguments" do
+      a = 1
+
+      configuration.before { |b| a += b }
+      configuration.before(2)
+
+      expect(a).to_equal 3
     end
   end
 


### PR DESCRIPTION
Because the `after_fork` callback must be established within a 
configuration block, attempts to manipulate the configuration object
fall prey to some wonky multithreading issues. Namely, there was no way 
to modify the global logger directly within the hook.

To work around these issues, we can pass the actual `Worker` object
through to our callback, giving users the flexibility to manipulate the
worker before the polling loop is initiated. The global logger will now
be inherited from the worker.