### PR TITLE
Prevent stale updates from being applied during sync

### DIFF
--- a/lib/restforce/db/accumulator.rb
+++ b/lib/restforce/db/accumulator.rb
@@ -57,14 +57,14 @@ module Restforce
         end
       end
 
-      # Public: Does the timestamp of the most recent change exceed the
+      # Public: Does the timestamp of the most recent change meet or exceed the
       # specified timestamp?
       #
       # timestamp - A Time object.
       #
       # Returns a Boolean.
-      def more_recent_than?(timestamp)
-        keys.sort.last > timestamp
+      def up_to_date_for?(timestamp)
+        keys.sort.last >= timestamp
       end
 
     end

--- a/lib/restforce/db/accumulator.rb
+++ b/lib/restforce/db/accumulator.rb
@@ -57,6 +57,16 @@ module Restforce
         end
       end
 
+      # Public: Does the timestamp of the most recent change exceed the
+      # specified timestamp?
+      #
+      # timestamp - A Time object.
+      #
+      # Returns a Boolean.
+      def more_recent_than?(timestamp)
+        keys.sort.last > timestamp
+      end
+
     end
 
   end

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -38,7 +38,7 @@ module Restforce
             database_instance.last_update,
             salesforce_instance.last_update,
           ].max
-          next unless accumulator.more_recent_than?(most_recent_timestamp)
+          next unless accumulator.up_to_date_for?(most_recent_timestamp)
 
           update(database_instance, accumulator)
           update(salesforce_instance, accumulator)

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -34,6 +34,12 @@ module Restforce
           salesforce_instance = @mapping.salesforce_record_type.find(id)
           next unless database_instance && salesforce_instance
 
+          most_recent_timestamp = [
+            database_instance.last_update,
+            salesforce_instance.last_update,
+          ].max
+          next unless accumulator.more_recent_than?(most_recent_timestamp)
+
           update(database_instance, accumulator)
           update(salesforce_instance, accumulator)
         end

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_database_record.yml
@@ -1,0 +1,197 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:15 GMT
+      Set-Cookie:
+      - BrowserId=NaqbSOCqRUG6T6kMI7khkA;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:15 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433535915696","token_type":"Bearer","instance_url":"https://<host>","signature":"fD9CLmClrzCnCIA6HkADFMT5/dCPYKYImpoZjvAkDic=","access_token":"00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE"}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:15 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:16 GMT
+      Set-Cookie:
+      - BrowserId=EYRZMT40RRiN-tBLEgOllw;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:16 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001c8ahAAA","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:16 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8ahAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:17 GMT
+      Set-Cookie:
+      - BrowserId=xQtzOGa1SL-c96vfqFd1-Q;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:17 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"},"Id":"a001a000001c8ahAAA","SystemModstamp":"2015-06-05T20:25:16.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:17 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8ahAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:18 GMT
+      Set-Cookie:
+      - BrowserId=GV0SXgQCSqWGC-GW2kbr7Q;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:18 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"},"Id":"a001a000001c8ahAAA","SystemModstamp":"2015-06-05T20:25:16.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:18 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:19 GMT
+      Set-Cookie:
+      - BrowserId=i2ttnY_IShCGquR_RqSKug;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:19 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:19 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_salesforce_record.yml
@@ -1,0 +1,236 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:20 GMT
+      Set-Cookie:
+      - BrowserId=Kty7tJAYT1qPGeq4D3Unug;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:20 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433535920475","token_type":"Bearer","instance_url":"https://<host>","signature":"O35nl1BtAs3tfVm7q9qvPHALERbq5y66/3Eo5ATxYCs=","access_token":"00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE"}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:20 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:21 GMT
+      Set-Cookie:
+      - BrowserId=LtnrKaJZSWGIynlqL75g8w;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:21 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001c8amAAA","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:21 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:22 GMT
+      Set-Cookie:
+      - BrowserId=kXFjdyBMQqCtOcPfbobm0g;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:22 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:22 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:23 GMT
+      Set-Cookie:
+      - BrowserId=GOzB5Yp2RQOKO5AakuKbng;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:23 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=6/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:23 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:24 GMT
+      Set-Cookie:
+      - BrowserId=fpDWWW5iRZ26VWwJw39FPg;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:24 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Jun 2015 20:25:24 GMT
+      Set-Cookie:
+      - BrowserId=UXTZHmJ4Q7eeBuTTDakbOQ;Path=/;Domain=.salesforce.com;Expires=Tue,
+        04-Aug-2015 20:25:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Jun 2015 20:25:25 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -96,4 +96,21 @@ describe Restforce::DB::Accumulator do
       expect(accumulator).to_not_be :changed?, yottle: "Bottle"
     end
   end
+
+  describe "#more_recent_than?" do
+    let(:timestamp) { Time.now }
+
+    before do
+      accumulator.store(timestamp, some: "set", of: "attributes")
+    end
+
+    it "returns true if the passed timestamp is less recent than the stored time" do
+      expect(accumulator).to_be :more_recent_than?, timestamp - 1
+    end
+
+    it "returns false if the passed timestamp is more recent than the stored time" do
+      expect(accumulator).to_not_be :more_recent_than?, timestamp + 1
+    end
+  end
+
 end

--- a/test/lib/restforce/db/accumulator_test.rb
+++ b/test/lib/restforce/db/accumulator_test.rb
@@ -97,7 +97,7 @@ describe Restforce::DB::Accumulator do
     end
   end
 
-  describe "#more_recent_than?" do
+  describe "#up_to_date_for?" do
     let(:timestamp) { Time.now }
 
     before do
@@ -105,11 +105,15 @@ describe Restforce::DB::Accumulator do
     end
 
     it "returns true if the passed timestamp is less recent than the stored time" do
-      expect(accumulator).to_be :more_recent_than?, timestamp - 1
+      expect(accumulator).to_be :up_to_date_for?, timestamp - 1
+    end
+
+    it "returns true if the passed timestamp is identical to the stored time" do
+      expect(accumulator).to_be :up_to_date_for?, timestamp
     end
 
     it "returns false if the passed timestamp is more recent than the stored time" do
-      expect(accumulator).to_not_be :more_recent_than?, timestamp + 1
+      expect(accumulator).to_not_be :up_to_date_for?, timestamp + 1
     end
   end
 

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -5,6 +5,7 @@ ActiveRecord::Base.establish_connection(
   adapter: "sqlite3",
   database: ":memory:",
 )
+ActiveSupport::TestCase.test_order = :random
 
 ActiveRecord::Schema.define do
 


### PR DESCRIPTION
When changes are made to a record _while_ synchronization occurs, we
don’t want to synchronize the now-stale changes back in — this would
discard the more recent changes, introducing a race condition.

Instead, we can rely on the fact that the change in timestamp reflects
a change which will be picked up on the next synchronization tick. This
will _delay_ the record synchronization, but will ultimately result in
the most recent, most accurate data being propagated.