### PR TITLE
Expose problematic record IDs on sync exception

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -9,6 +9,7 @@ require "restforce/db/configuration"
 require "restforce/db/registry"
 require "restforce/db/strategy"
 require "restforce/db/dsl"
+require "restforce/db/synchronization_error"
 
 require "restforce/db/association_cache"
 require "restforce/db/associations/base"

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -74,7 +74,7 @@ module Restforce
           database_record.save!
         end
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
-        DB.logger.error(e)
+        DB.logger.error(SynchronizationError.new(e, salesforce_instance))
       end
 
       # Internal: Get a Hash of associated lookup IDs for the passed database

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -43,7 +43,7 @@ module Restforce
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
       rescue ActiveRecord::ActiveRecordError => e
-        DB.logger.error(e)
+        DB.logger.error(SynchronizationError.new(e, instance))
       end
 
       # Internal: Attempt to create a partner record in Salesforce for the
@@ -57,7 +57,7 @@ module Restforce
         return if instance.synced?
         @mapping.salesforce_record_type.create!(instance)
       rescue Faraday::Error::ClientError => e
-        DB.logger.error(e)
+        DB.logger.error(SynchronizationError.new(e, instance))
       end
 
     end

--- a/lib/restforce/db/instances/active_record.rb
+++ b/lib/restforce/db/instances/active_record.rb
@@ -9,10 +9,12 @@ module Restforce
       # reconcile record attributes with Salesforce instances.
       class ActiveRecord < Base
 
-        # Public: Get a common identifier for this record.
+        # Public: Get a common identifier for this record. If the record is
+        # unsynchronized, returns a database-specific identifier.
         #
         # Returns a String.
         def id
+          return "#{@record_type}::#{@record.id}" unless synced?
           @record.send(@mapping.lookup_column)
         end
 

--- a/lib/restforce/db/synchronization_error.rb
+++ b/lib/restforce/db/synchronization_error.rb
@@ -1,0 +1,40 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::SynchronizationError is a thin wrapper for any sort of
+    # exception that might crop up during our record synchronization. It exposes
+    # the Salesforce ID (or database identifier, for unsynced records) of the
+    # record which triggered the exception.
+    class SynchronizationError < RuntimeError
+
+      attr_reader :base_exception
+
+      extend Forwardable
+      def_delegators(
+        :base_exception,
+        :class,
+        :backtrace,
+      )
+
+      # Public: Initialize a new SynchronizationError.
+      #
+      # base_exception - An exception which should be logged.
+      # instance       - A Restforce::DB::Instances::Base representing a record.
+      def initialize(base_exception, instance)
+        @base_exception = base_exception
+        @instance = instance
+      end
+
+      # Public: Get the message for this exception. Prepends the Salesforce ID.
+      #
+      # Returns a String.
+      def message
+        "[#{@instance.id}] #{base_exception.message}"
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -19,8 +19,8 @@ module Restforce
       # record descriptors to attributes.
       #
       # NOTE: Synchronizer assumes that the propagation step has done its job
-      # correctly. If we can't locate a database record for a specific Salsforce
-      # ID, we assume it shouldn't be synchronized.
+      # correctly. If we can't locate a database record for a specific
+      # Salesforce ID, we assume it shouldn't be synchronized.
       #
       # changes - A Hash, with keys composed of a Salesforce ID and model name,
       #           with Restforce::DB::Accumulator objects as values.
@@ -62,7 +62,7 @@ module Restforce
 
         instance.update!(attributes)
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
-        DB.logger.error(e)
+        DB.logger.error(SynchronizationError.new(e, instance))
       end
 
     end

--- a/test/lib/restforce/db/instances/active_record_test.rb
+++ b/test/lib/restforce/db/instances/active_record_test.rb
@@ -10,6 +10,27 @@ describe Restforce::DB::Instances::ActiveRecord do
     Restforce::DB::Instances::ActiveRecord.new(database_model, record, mapping)
   end
 
+  describe "#id" do
+
+    describe "when the record has no synchronized Salesforce ID" do
+
+      it "returns the record's ID" do
+        expect(instance.id).to_equal "CustomObject::#{record.id}"
+      end
+    end
+
+    describe "when the record has a synchronized Salesforce ID" do
+      let(:salesforce_id) { "a001a000001E1vREAL" }
+      before do
+        record.update!(salesforce_id: salesforce_id)
+      end
+
+      it "returns the Salesforce ID" do
+        expect(instance.id).to_equal salesforce_id
+      end
+    end
+  end
+
   describe "#update!" do
     let(:text) { "Some new text" }
 


### PR DESCRIPTION
When a validation on either side of the integration fails, it’s 
extremely helpful to be able to locate the record which caused the sync
issue. To that end, we can expose the Salesforce ID (or database record
ID, in the event that an unsynchronized database record is causing the
problem) in our error message, to greatly assist in debugging efforts.

I originally wanted to get `SynchronizationError` working as a delegator
on top of the base exception, but I couldn't figure out a reasonable
workaround for some quirks in `Exception.===`'s behavior, so I settled
for just delegating a handful of relevant methods.