### PR TITLE
Accept sequential internal record updates

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -91,6 +91,14 @@ module Restforce
       )
     end
 
+    # Public: Get the ID of the Salesforce user which is being used to access
+    # the Salesforce API.
+    #
+    # Returns a String.
+    def self.user_id
+      @user_id ||= client.user_info.user_id
+    end
+
     # Public: Configure Restforce::DB by assigning values to the current
     # configuration.
     #

--- a/lib/restforce/db/instances/active_record.rb
+++ b/lib/restforce/db/instances/active_record.rb
@@ -16,13 +16,6 @@ module Restforce
           @record.send(@mapping.lookup_column)
         end
 
-        # Public: Has this record been synced to a Salesforce record?
-        #
-        # Returns a Boolean.
-        def synced?
-          @record.send(:"#{@mapping.lookup_column}?")
-        end
-
         # Public: Get the time of the last update to this record.
         #
         # Returns a Time-compatible object.
@@ -36,6 +29,21 @@ module Restforce
         # Returns a Time-compatible object.
         def last_synchronize
           @record.synchronized_at
+        end
+
+        # Public: Has this record been synced to a Salesforce record?
+        #
+        # Returns a Boolean.
+        def synced?
+          @record.send(:"#{@mapping.lookup_column}?")
+        end
+
+        # Public: Was this record most recently updated by Restforce::DB's
+        # workflow?
+        #
+        # Returns a Boolean.
+        def updated_internally?
+          last_synchronize.to_i >= last_update.to_i
         end
 
         # Public: Bump the synchronization timestamp on the record.

--- a/lib/restforce/db/instances/salesforce.rb
+++ b/lib/restforce/db/instances/salesforce.rb
@@ -12,6 +12,7 @@ module Restforce
         INTERNAL_ATTRIBUTES = %w(
           Id
           SystemModstamp
+          LastModifiedById
         ).freeze
 
         # Public: Get a common identifier for this record.
@@ -51,6 +52,14 @@ module Restforce
         # Returns a Boolean.
         def synced?
           @mapping.database_model.exists?(@mapping.lookup_column => id)
+        end
+
+        # Public: Was this record most recently updated by Restforce::DB's
+        # workflow?
+        #
+        # Returns a Boolean.
+        def updated_internally?
+          @record.LastModifiedById == DB.user_id
         end
 
       end

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:27 GMT
+      - Mon, 08 Jun 2015 22:12:32 GMT
       Set-Cookie:
-      - BrowserId=FY9VBGWDTKOLnfn0YRc09A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:27 GMT
+      - BrowserId=Gpv2ju6aQEe8-0x8dK9RIw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428631827849","token_type":"Bearer","instance_url":"https://<host>","signature":"BXGR8ydlpCf8EvBey3owrmD+t8H2Xwv4wg5rPNZH7o0=","access_token":"00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW"}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:29 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801552514","token_type":"Bearer","instance_url":"https://<host>","signature":"jR8TwzE1K7eJmvEIAB/CwvmUpLO++wMy6JrY2U6ApRI=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:34 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:30 GMT
+      - Mon, 08 Jun 2015 22:12:32 GMT
       Set-Cookie:
-      - BrowserId=6-GstZaCR1uEQGIPRQbjwA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:30 GMT
+      - BrowserId=37umUA-kQiyZa_VHsT17hg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=10/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMoAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001y45eAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:30 GMT
+      string: '{"id":"0031a000004cfMoAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:34 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001y45eAAA"}'
+      string: '{"Friend__c":"0031a000004cfMoAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:31 GMT
+      - Mon, 08 Jun 2015 22:12:32 GMT
       Set-Cookie:
-      - BrowserId=ToZfBFxvREKP_xa5EJEGNg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:31 GMT
+      - BrowserId=aWkGvUiMT92OB8TG0j0OSA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=12/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5AAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LS2EAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:31 GMT
+      string: '{"id":"a001a000001cF5AAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:34 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2EAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5AAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,10 +145,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:32 GMT
+      - Mon, 08 Jun 2015 22:12:33 GMT
       Set-Cookie:
-      - BrowserId=wSa0yGdqRY21w58q9qGeiw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:32 GMT
+      - BrowserId=JHHY4v-2SWitUxFQ0qr3iQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -159,12 +159,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW"},"Id":"a001a000001LS2EAAW","SystemModstamp":"2015-04-10T02:10:31.000+0000","Name":"a001a000001LS2E","Example_Field__c":null,"Friend__c":"0031a000001y45eAAA"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:32 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5AAAU"},"Id":"a001a000001cF5AAAU","SystemModstamp":"2015-06-08T22:12:32.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF5A","Example_Field__c":null,"Friend__c":"0031a000004cfMoAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:34 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001y45eAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMoAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,10 +183,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:33 GMT
+      - Mon, 08 Jun 2015 22:12:33 GMT
       Set-Cookie:
-      - BrowserId=wJyFDAF4T3i6yXDBP6z6Jw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:33 GMT
+      - BrowserId=d_bPQ3W6QqSAIplgGXlcGA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -197,12 +197,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA"},"Id":"0031a000001y45eAAA","SystemModstamp":"2015-04-10T02:10:30.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:33 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMoAAI"},"Id":"0031a000004cfMoAAI","SystemModstamp":"2015-06-08T22:12:32.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:34 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001y45eAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMoAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,10 +221,10 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:34 GMT
+      - Mon, 08 Jun 2015 22:12:33 GMT
       Set-Cookie:
-      - BrowserId=oky5yaNtQlSK9UVhJpAnvQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:34 GMT
+      - BrowserId=w_dEnJnWQ76qT74cRj4chw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:34 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:35 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2EAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5AAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,10 +255,10 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:10:35 GMT
+      - Mon, 08 Jun 2015 22:12:33 GMT
       Set-Cookie:
-      - BrowserId=zymXJDyvSpGTuUi-0iLM_Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:10:35 GMT
+      - BrowserId=zxjQmM5tRriwTIKOZVY98Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -266,6 +266,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:10:35 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:35 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:25:30 GMT
+      - Mon, 08 Jun 2015 22:13:25 GMT
       Set-Cookie:
-      - BrowserId=CXWuPSH8QvCYOFUGY4K_-g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:25:30 GMT
+      - BrowserId=1e58c5YKTSmZBWQ6JZPF8g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557930126","token_type":"Bearer","instance_url":"https://<host>","signature":"r67C8yGA3MlpIHibA9/5ixX6k3b4vIgUwX+3d1iC3Qs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:25:30 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801605122","token_type":"Bearer","instance_url":"https://<host>","signature":"Lr2zH8d72KNS/xZ5WdutRZLFAWQxw5nxHU8s0p6DO4U=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:26 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:25:31 GMT
+      - Mon, 08 Jun 2015 22:13:25 GMT
       Set-Cookie:
-      - BrowserId=m-mQLSZGT5ywhOztVhoACA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:25:31 GMT
+      - BrowserId=AzL_4vk2S-iT1V4GBIcvoQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=116/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7kAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001MG7WAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:25:31 GMT
+      string: '{"id":"a001a000001cF7kAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:26 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MG7WAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7kAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,26 +103,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:25:31 GMT
+      - Mon, 08 Jun 2015 22:13:25 GMT
       Set-Cookie:
-      - BrowserId=7lkL7l8_SNuY-kCjNc0jFA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:25:31 GMT
+      - BrowserId=ZgjUeA5pRbmM9xcy_DHIWw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=112/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW"},"Id":"a001a000001MG7WAAW","SystemModstamp":"2015-04-20T19:25:31.000+0000","Name":"a001a000001MG7W","Example_Field__c":null,"Friend__c":null}]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:25:32 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7kAAE"},"Id":"a001a000001cF7kAAE","SystemModstamp":"2015-06-08T22:13:25.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF7k","Example_Field__c":null,"Friend__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%27%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%27%27
     body:
       encoding: US-ASCII
       string: ''
@@ -130,7 +130,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -141,14 +141,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:25:33 GMT
+      - Mon, 08 Jun 2015 22:13:25 GMT
       Set-Cookie:
-      - BrowserId=AoKaatypTjaBpGNgJAH23A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:25:33 GMT
+      - BrowserId=ksoXt24WSTqrB2gmbi0Zvg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=122/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -156,11 +156,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:25:33 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:27 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MG7WAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7kAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -168,7 +168,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -179,17 +179,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:25:34 GMT
+      - Mon, 08 Jun 2015 22:13:25 GMT
       Set-Cookie:
-      - BrowserId=GkhRvxVRRTCj8d09-Dp6Kw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:25:34 GMT
+      - BrowserId=mM8-Kl9cRJ-q6xPWTpK_dA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=113/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:25:34 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:14 GMT
+      - Mon, 08 Jun 2015 22:12:10 GMT
       Set-Cookie:
-      - BrowserId=OrIb41RKR1mxYX5PD2RcFQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:14 GMT
+      - BrowserId=wYhaXKCJQtqgl4WyC1-mDA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429810394922","token_type":"Bearer","instance_url":"https://<host>","signature":"qD5Hnlij9mqvLquOno/CQKE+/oNFSOhawRLJvX4MVpE=","access_token":"00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l"}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:15 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801530702","token_type":"Bearer","instance_url":"https://<host>","signature":"XIkv4Kc+q8mWSAD7LsSYDtoSBo1JikRwkNY9VE8g7lw=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:12 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:15 GMT
+      - Mon, 08 Jun 2015 22:12:10 GMT
       Set-Cookie:
-      - BrowserId=LGloqy6ATQSeJz9TIl9ohg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:15 GMT
+      - BrowserId=HB7pTfAyT-uftGzW7AX6-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=5/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMKAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002fBHlAAM","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:16 GMT
+      string: '{"id":"0031a000004cfMKAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:13 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002fBHlAAM"}'
+      string: '{"Friend__c":"0031a000004cfMKAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:17 GMT
+      - Mon, 08 Jun 2015 22:12:11 GMT
       Set-Cookie:
-      - BrowserId=SaqTi4_pTU6Wzn2Bfq6KEg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:17 GMT
+      - BrowserId=rXDKcxVxSqG9G-BMHBEhEA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF42AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001QmhqAAC","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:17 GMT
+      string: '{"id":"a001a000001cF42AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:13 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhqAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF42AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:18 GMT
+      - Mon, 08 Jun 2015 22:12:11 GMT
       Set-Cookie:
-      - BrowserId=_63UXHLGRReEluJDxNNTTg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:18 GMT
+      - BrowserId=yE1MwawzTZe6PfXjUYAySA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC"},"Id":"a001a000001QmhqAAC","SystemModstamp":"2015-04-23T17:33:17.000+0000","Name":"a001a000001Qmhq","Example_Field__c":null,"Friend__c":"0031a000002fBHlAAM"}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:18 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF42AAE"},"Id":"a001a000001cF42AAE","SystemModstamp":"2015-06-08T22:12:11.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF42","Example_Field__c":null,"Friend__c":"0031a000004cfMKAAY"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:13 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002fBHlAAM%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMKAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:18 GMT
+      - Mon, 08 Jun 2015 22:12:12 GMT
       Set-Cookie:
-      - BrowserId=VITtDGw1SFizllC79xjnpw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:18 GMT
+      - BrowserId=kKRBoemzQzybGrHCsiAEVQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM"},"Id":"0031a000002fBHlAAM","SystemModstamp":"2015-04-23T17:33:16.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:19 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMKAAY"},"Id":"0031a000004cfMKAAY","SystemModstamp":"2015-06-08T22:12:11.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:13 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002fBHlAAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMKAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:19 GMT
+      - Mon, 08 Jun 2015 22:12:12 GMT
       Set-Cookie:
-      - BrowserId=g_8s18RQQzKapDhMAJLIOw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:19 GMT
+      - BrowserId=ZjBTji8BRbmMlQxfFG2pcQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:20 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:14 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhqAAC
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF42AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:33:21 GMT
+      - Mon, 08 Jun 2015 22:12:12 GMT
       Set-Cookie:
-      - BrowserId=_83pmWlQSA67o0QhpVdJNQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:33:21 GMT
+      - BrowserId=kRXZEiehRiWoBBp0rh-8rg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:33:21 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:24 GMT
+      - Mon, 08 Jun 2015 22:12:49 GMT
       Set-Cookie:
-      - BrowserId=V4xV6073TGS_LEesUDd-EA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:24 GMT
+      - BrowserId=ji8zmkY2QaWIgZbQcRbO2Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430498004388","token_type":"Bearer","instance_url":"https://<host>","signature":"UlHQTMd5UMeQOcODXUr6CtDraNkn2Wq50gFTzKBlpT8=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:24 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801569338","token_type":"Bearer","instance_url":"https://<host>","signature":"gIK6JasSWG6R4Ee8vy/PT0YmCObQXqTGDylgxZXhPrQ=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:50 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:24 GMT
+      - Mon, 08 Jun 2015 22:12:49 GMT
       Set-Cookie:
-      - BrowserId=7i8VqQngSSqFKsKsi7Vk_g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:24 GMT
+      - BrowserId=DD-U9GLMSnW1IoBmAmO4UA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/15000
+      - api-usage=30/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfN8AAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002jr5yAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:24 GMT
+      string: '{"id":"0031a000004cfN8AAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:51 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002jr5yAAA"}'
+      string: '{"Friend__c":"0031a000004cfN8AAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:24 GMT
+      - Mon, 08 Jun 2015 22:12:49 GMT
       Set-Cookie:
-      - BrowserId=HqVkQER3SLGWhf169ZcfYw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:24 GMT
+      - BrowserId=_eM0RYwcT0y185l8dWGDKA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/15000
+      - api-usage=27/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5yAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001TuPCAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:25 GMT
+      string: '{"id":"a001a000001cF5yAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:51 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuPCAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5yAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:25 GMT
+      - Mon, 08 Jun 2015 22:12:50 GMT
       Set-Cookie:
-      - BrowserId=HFIYWjmgQESnRKolxabijg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:25 GMT
+      - BrowserId=RQFna1DsTgCWW-6rnaKnRA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/15000
+      - api-usage=26/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0"},"Id":"a001a000001TuPCAA0","SystemModstamp":"2015-05-01T16:33:24.000+0000","Name":"a001a000001TuPC","Example_Field__c":null,"Friend__c":"0031a000002jr5yAAA"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:25 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5yAAE"},"Id":"a001a000001cF5yAAE","SystemModstamp":"2015-06-08T22:12:49.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF5y","Example_Field__c":null,"Friend__c":"0031a000004cfN8AAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:51 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5yAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfN8AAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:25 GMT
+      - Mon, 08 Jun 2015 22:12:50 GMT
       Set-Cookie:
-      - BrowserId=fbjM_aMCQk-C-vEXZy2qsg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:25 GMT
+      - BrowserId=RU5jJ7Y4RHKzdqxhVuaE4A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=16/15000
+      - api-usage=24/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA"},"Id":"0031a000002jr5yAAA","SystemModstamp":"2015-05-01T16:33:24.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:25 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfN8AAI"},"Id":"0031a000004cfN8AAI","SystemModstamp":"2015-06-08T22:12:49.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:51 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5yAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfN8AAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:25 GMT
+      - Mon, 08 Jun 2015 22:12:50 GMT
       Set-Cookie:
-      - BrowserId=9sf6dtHySYeEZem-2Pu2UA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:25 GMT
+      - BrowserId=66eiMJjySAOpP6hpfGCVwA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=28/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:25 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:52 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuPCAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5yAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:25 GMT
+      - Mon, 08 Jun 2015 22:12:50 GMT
       Set-Cookie:
-      - BrowserId=kXuMYUa-TeafZ0Rlz2v3Tw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:25 GMT
+      - BrowserId=tCD9WrUKQoOBx0G5ZBR_aw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/15000
+      - api-usage=34/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:26 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:14 GMT
+      - Mon, 08 Jun 2015 22:12:44 GMT
       Set-Cookie:
-      - BrowserId=V9dFLjV5TievBVtXBTgLWg;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:14 GMT
+      - BrowserId=vcNEhUTASfyOp-hjq4qu6Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460634690","token_type":"Bearer","instance_url":"https://<host>","signature":"I1sgPTyHS2c7Q4mY6uYgi366rdlGdYcRwz3opVrE+58=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:14 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801564382","token_type":"Bearer","instance_url":"https://<host>","signature":"ftVZkXfl5W3sZ0wvKG0/scdP2SI44XH4dj4gnXFSnpU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:45 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:16 GMT
+      - Mon, 08 Jun 2015 22:12:44 GMT
       Set-Cookie:
-      - BrowserId=xiEWPErTSdeEBjwIUT0J3w;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:16 GMT
+      - BrowserId=iQP5h5UySlGFafW0i_EdIQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=28/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000003Gm5NAAS"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfN3AAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000003Gm5NAAS","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:16 GMT
+      string: '{"id":"0031a000004cfN3AAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:46 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000003Gm5NAAS"}'
+      string: '{"Friend__c":"0031a000004cfN3AAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:17 GMT
+      - Mon, 08 Jun 2015 22:12:44 GMT
       Set-Cookie:
-      - BrowserId=4lHsZnLEReGCcTNe30pcuA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:17 GMT
+      - BrowserId=3biOjBcmRYqb-aeJ4Ij2Hg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=26/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5oAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZKKDAA4","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:17 GMT
+      string: '{"id":"a001a000001cF5oAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:46 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKKDAA4%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5oAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:18 GMT
+      - Mon, 08 Jun 2015 22:12:45 GMT
       Set-Cookie:
-      - BrowserId=cpODyp_6RtSVX3OwT0Rm3Q;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:18 GMT
+      - BrowserId=E_k6BKFhTfeQFR-Gf-RVFQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=24/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4"},"Id":"a001a000001ZKKDAA4","SystemModstamp":"2015-05-12T19:57:17.000+0000","Name":"a001a000001ZKKD","Example_Field__c":null,"Friend__c":"0031a000003Gm5NAAS"}]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:18 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5oAAE"},"Id":"a001a000001cF5oAAE","SystemModstamp":"2015-06-08T22:12:44.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF5o","Example_Field__c":null,"Friend__c":"0031a000004cfN3AAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:46 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003Gm5NAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfN3AAI
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,22 +183,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:19 GMT
+      - Mon, 08 Jun 2015 22:12:45 GMT
       Set-Cookie:
-      - BrowserId=3VOrxur8Rvq-ronZBZbAYw;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:19 GMT
+      - BrowserId=_oQFBneeQmGzuhytPhGcdg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/15000
+      - api-usage=29/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:46 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKKDAA4
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5oAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -206,7 +206,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -217,17 +217,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:20 GMT
+      - Mon, 08 Jun 2015 22:12:45 GMT
       Set-Cookie:
-      - BrowserId=JBvgCXUUQE6C-I39j-qI9Q;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:20 GMT
+      - BrowserId=znYwzrZSSwS18jNyw_svPQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/15000
+      - api-usage=25/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:20 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/with_an_unrelated_association_mapping/proceeds_without_raising_an_error.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_build/with_an_unrelated_association_mapping/proceeds_without_raising_an_error.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:37 GMT
+      - Mon, 08 Jun 2015 22:12:34 GMT
       Set-Cookie:
-      - BrowserId=pJidk7gYQ3GCVEMb1Z-p0g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:37 GMT
+      - BrowserId=MoYAX0MaQrGSG-2b83t6XQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429758817565","token_type":"Bearer","instance_url":"https://<host>","signature":"ETRbdU1qbtTF4bZuRhnk3OFfLRmxZRMXihMo3PgUaCc=","access_token":"00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH"}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:37 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801554931","token_type":"Bearer","instance_url":"https://<host>","signature":"3ummgSBm9g11fK/LAPfxUVeXNeaVgvMmMhqh9BeKjro=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:36 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:38 GMT
+      - Mon, 08 Jun 2015 22:12:35 GMT
       Set-Cookie:
-      - BrowserId=5Nut_wCxQuKIC63Zx74A7A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:38 GMT
+      - BrowserId=-EHk_JSFQ4iJ-_EBit32AQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=13/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMtAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002eu2wAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:39 GMT
+      string: '{"id":"0031a000004cfMtAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:36 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002eu2wAAA"}'
+      string: '{"Friend__c":"0031a000004cfMtAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:40 GMT
+      - Mon, 08 Jun 2015 22:12:35 GMT
       Set-Cookie:
-      - BrowserId=GQLMiMKEQ42kgZCYY5_Guw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:40 GMT
+      - BrowserId=hWyOTt0uQhO7dsLCpPtACQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=12/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5KAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001QkMJAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:40 GMT
+      string: '{"id":"a001a000001cF5KAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:36 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QkMJAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5KAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:41 GMT
+      - Mon, 08 Jun 2015 22:12:35 GMT
       Set-Cookie:
-      - BrowserId=XUQn0DWrTke9Ylns2VGOoQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:41 GMT
+      - BrowserId=1M_PxShAQ7i_3ti5j9kCkQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=9/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0"},"Id":"a001a000001QkMJAA0","SystemModstamp":"2015-04-23T03:13:40.000+0000","Name":"a001a000001QkMJ","Example_Field__c":null,"Friend__c":"0031a000002eu2wAAA"}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:41 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5KAAU"},"Id":"a001a000001cF5KAAU","SystemModstamp":"2015-06-08T22:12:35.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF5K","Example_Field__c":null,"Friend__c":"0031a000004cfMtAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:37 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002eu2wAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMtAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:42 GMT
+      - Mon, 08 Jun 2015 22:12:35 GMT
       Set-Cookie:
-      - BrowserId=3Vfxi4vKSCqE0GyreWo3XA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:42 GMT
+      - BrowserId=ZY_0WLeTRD2XlkEaYr3D_Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=12/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA"},"Id":"0031a000002eu2wAAA","SystemModstamp":"2015-04-23T03:13:38.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:42 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMtAAI"},"Id":"0031a000004cfMtAAI","SystemModstamp":"2015-06-08T22:12:35.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:37 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002eu2wAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMtAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:43 GMT
+      - Mon, 08 Jun 2015 22:12:35 GMT
       Set-Cookie:
-      - BrowserId=8tDMUoSmSIqzGT4fCP8feg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:43 GMT
+      - BrowserId=bnajkSohQLyzgWsWuGwyxg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:35 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=10/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:43 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:37 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QkMJAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5KAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQI3jppS_aXZi3eoU3Ztk8o91RYAqZvR2D51oCqu62M0uC1FFl0QlLq8SSc7KMviWaMD3qj3R.OxDi5v6FJ24v5LjiUBH
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 23 Apr 2015 03:13:44 GMT
+      - Mon, 08 Jun 2015 22:12:36 GMT
       Set-Cookie:
-      - BrowserId=ONVEXduoQtKJxklXKfwf9A;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 03:13:44 GMT
+      - BrowserId=4_2A7yP8QpShs5rx6WGJ6g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=11/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 03:13:44 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:37 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/returns_a_hash_of_the_associated_records_lookup_IDs.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 04 May 2015 03:03:46 GMT
+      - Mon, 08 Jun 2015 22:12:54 GMT
       Set-Cookie:
-      - BrowserId=xEedI-vySRW2ERl7-YhVMQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:03:46 GMT
+      - BrowserId=oEafweUzQPiY4YUIKZDBzQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430708626705","token_type":"Bearer","instance_url":"https://<host>","signature":"l9dFCE7hnrj+RVNOaga2AVC08CivElFFEXzzLx249cg=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:03:46 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801575044","token_type":"Bearer","instance_url":"https://<host>","signature":"vC2VGv4Jw9qhv21bWwhk+sN0NSmLPw0f9zeU2bc/XFc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:56 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 04 May 2015 03:03:47 GMT
+      - Mon, 08 Jun 2015 22:12:55 GMT
       Set-Cookie:
-      - BrowserId=JXXP7EFFSGmPNZoB147Iaw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:03:47 GMT
+      - BrowserId=J_7rKD4BSuCr1ptg6a5VEQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/15000
+      - api-usage=33/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a00000317qmAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNDAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a00000317qmAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:03:47 GMT
+      string: '{"id":"0031a000004cfNDAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:56 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a00000317qmAAA"}'
+      string: '{"Friend__c":"0031a000004cfNDAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 04 May 2015 03:03:48 GMT
+      - Mon, 08 Jun 2015 22:12:55 GMT
       Set-Cookie:
-      - BrowserId=JSTACFWYRfGvSN-pXUImfQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:03:48 GMT
+      - BrowserId=X-Ph3To2R7yNhoW3xRYD5Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/15000
+      - api-usage=28/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16LAAS"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6IAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001U16LAAS","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:03:49 GMT
+      string: '{"id":"a001a000001cF6IAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:57 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a00000317qmAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNDAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,22 +145,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 04 May 2015 03:03:49 GMT
+      - Mon, 08 Jun 2015 22:12:55 GMT
       Set-Cookie:
-      - BrowserId=fw6pUrTnSsaUmxeHralylA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:03:49 GMT
+      - BrowserId=zzwF-SLgRuCFTG9lXZYCiQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/15000
+      - api-usage=35/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:03:50 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:57 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16LAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6IAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -168,7 +168,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -179,17 +179,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 04 May 2015 03:03:51 GMT
+      - Mon, 08 Jun 2015 22:12:55 GMT
       Set-Cookie:
-      - BrowserId=dZMbqhy9So-af3I7wNJe7w;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:03:51 GMT
+      - BrowserId=G3FJrkoLSOSqNhQCrz7XqA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:55 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=62/15000
+      - api-usage=34/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:03:51 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:57 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_a_nil_lookup_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_a_nil_lookup_value_in_the_hash.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 May 2015 21:06:48 GMT
+      - Mon, 08 Jun 2015 22:13:09 GMT
       Set-Cookie:
-      - BrowserId=ByBZSCL6S7-SC1BiTBWUiw;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 21:06:48 GMT
+      - BrowserId=OGBRkBG5TcCDtXq4dfCyXg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1432069609059","token_type":"Bearer","instance_url":"https://<host>","signature":"zfbrLMOjqIUvY4r6QBb65KMC5wUj6Z/2Ll6lwfEX9xc=","access_token":"00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801589823","token_type":"Bearer","instance_url":"https://<host>","signature":"htAfKmSOA3TOkkbsDb8Yb5PM6xTpCg8IgRqdHHI1o/0=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 21:06:49 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:11 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 May 2015 21:06:50 GMT
+      - Mon, 08 Jun 2015 22:13:09 GMT
       Set-Cookie:
-      - BrowserId=1OdDxkXQRi-VcR2auOFilA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 21:06:50 GMT
+      - BrowserId=J_82CrFrTIWN8nUr6uom4g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/15000
+      - api-usage=77/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a9cUAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF71AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001a9cUAAQ","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF71AAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 21:06:50 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a9cUAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF71AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOFtHn3SE6gPxdfhwmVytgEfpF6iCa307owP1OL6HYF1obRFYNjghLuR.QxkIkRyZu3Evw87_wGS4GT5_YkwqxjLFESh
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,17 +103,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 19 May 2015 21:06:51 GMT
+      - Mon, 08 Jun 2015 22:13:10 GMT
       Set-Cookie:
-      - BrowserId=F2NnH09RSISLTmIFu-lAoA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 21:06:51 GMT
+      - BrowserId=fwV63u-jT9-Jvo2OZMGx_A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=35/15000
+      - api-usage=72/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 May 2015 21:06:51 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:11 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_a_nil_lookup_value_in_the_hash.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 04 May 2015 03:11:53 GMT
+      - Mon, 08 Jun 2015 22:13:12 GMT
       Set-Cookie:
-      - BrowserId=xMX1dTw3TIGcKjfx_Cujpw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:11:53 GMT
+      - BrowserId=rTItl4RwRdyKlJbq5P8IXw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430709113521","token_type":"Bearer","instance_url":"https://<host>","signature":"2BWFc3pyXdIWgSNtXnE+OpZDdD+Oas7Mk3KKVvtfEzw=","access_token":"00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX"}'
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:11:53 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801592354","token_type":"Bearer","instance_url":"https://<host>","signature":"FGNgNSVt8fvGtlvH695klUqpcIT9k3bhSdR5/bDTomc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:13 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 04 May 2015 03:11:54 GMT
+      - Mon, 08 Jun 2015 22:13:12 GMT
       Set-Cookie:
-      - BrowserId=5-H8lcRDTYW0wIDWnj21qA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:11:54 GMT
+      - BrowserId=RU7t89JoQvGnFDQHPbb1-A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/15000
+      - api-usage=74/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16VAAS"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7BAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001U16VAAS","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:11:54 GMT
+      string: '{"id":"a001a000001cF7BAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:14 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001U16VAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7BAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNDrKHLCuinZBZ4a3F0V9mX6K..kuE6uPghr4hEJlGztbaV7OXvvfrl14zZZxgwsTH9RfcLkE1Wikbn..Xma3Bd5XKSX
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,17 +103,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 04 May 2015 03:11:55 GMT
+      - Mon, 08 Jun 2015 22:13:12 GMT
       Set-Cookie:
-      - BrowserId=7IbTrRJmRZCYf_zWQWFUKQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        03-Jul-2015 03:11:55 GMT
+      - BrowserId=q2c4WS8JQdqVjKNdMoT4sw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:12 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=66/15000
+      - api-usage=68/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 04 May 2015 03:11:55 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:14 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:50 GMT
+      - Mon, 08 Jun 2015 22:13:23 GMT
       Set-Cookie:
-      - BrowserId=wxVKkgCtS0iqyMbtQnfpwg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:50 GMT
+      - BrowserId=1gyu7M9wTciKjiTPy__B6w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715430707","token_type":"Bearer","instance_url":"https://<host>","signature":"GqowJrZwZnvh/FQmaN/zR2DJsm9BQNYlk+S4ewYO+s4=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:51 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801603354","token_type":"Bearer","instance_url":"https://<host>","signature":"w+4atIfiYsYitTK+Y4PVy6YS1O9ELl49MMofC8MCnII=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:24 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:52 GMT
+      - Mon, 08 Jun 2015 22:13:23 GMT
       Set-Cookie:
-      - BrowserId=Fw86cXceQQ6uq3NGexsHLw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:52 GMT
+      - BrowserId=5WQLWnG1SqKPIIZURHeB4w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/15000
+      - api-usage=104/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZN7AAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNdAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001yZN7AAM","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:53 GMT
+      string: '{"id":"0031a000004cfNdAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:25 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001yZN7AAM"}'
+      string: '{"Friend__c":"0031a000004cfNdAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,104 +105,104 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:54 GMT
+      - Mon, 08 Jun 2015 22:13:23 GMT
       Set-Cookie:
-      - BrowserId=WTpUCqKNTraZywGUlNicww;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:54 GMT
+      - BrowserId=BLsBYB6SQx-HEV_nZvfzVA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:23 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=114/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF43AAE"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001cF43AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:25 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF43AAE%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:13:24 GMT
+      Set-Cookie:
+      - BrowserId=FC-2cmbLQ3-Z3KkNAC55aQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=105/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF43AAE"},"Id":"a001a000001cF43AAE","SystemModstamp":"2015-06-08T22:13:23.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF43","Example_Field__c":null,"Friend__c":"0031a000004cfNdAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:25 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF43AAE%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:13:24 GMT
+      Set-Cookie:
+      - BrowserId=9RWzdIPvR6SABGIW4aFvng;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
       - api-usage=104/15000
-      Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgVAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:54 GMT
-- request:
-    method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sat, 11 Apr 2015 01:23:55 GMT
-      Set-Cookie:
-      - BrowserId=yLwk0BE-Ss220Wk6te85NQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:55 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=105/15000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:56 GMT
-- request:
-    method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgVAAW%27
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sat, 11 Apr 2015 01:23:57 GMT
-      Set-Cookie:
-      - BrowserId=FXOhyMjuTeOqg7AeJJPytw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:57 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=105/15000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW"},"Id":"a001a000001LXgVAAW","SystemModstamp":"2015-04-11T01:23:54.000+0000","Name":"a001a000001LXgV","Example_Field__c":null,"Friend__c":"0031a000001yZN7AAM"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:58 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF43AAE"},"Id":"a001a000001cF43AAE","SystemModstamp":"2015-06-08T22:13:23.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF43","Example_Field__c":null,"Friend__c":"0031a000004cfNdAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:25 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZN7AAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNdAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:58 GMT
+      - Mon, 08 Jun 2015 22:13:24 GMT
       Set-Cookie:
-      - BrowserId=UBitBTBlSxCu9Zf0gKy-Gg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:58 GMT
+      - BrowserId=10nsVKWqSSSSP32WEV-NkA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/15000
+      - api-usage=106/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:59 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:26 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgVAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF43AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:59 GMT
+      - Mon, 08 Jun 2015 22:13:24 GMT
       Set-Cookie:
-      - BrowserId=i1yP-cSvQdKBCnLItTDKzw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:59 GMT
+      - BrowserId=mundqCrTRjaaXBLi3LQPmA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=103/15000
+      - api-usage=110/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:24:00 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:26 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:12 GMT
+      - Mon, 08 Jun 2015 22:13:16 GMT
       Set-Cookie:
-      - BrowserId=BTKOVPdmQySASfnudICz-w;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:12 GMT
+      - BrowserId=rBaNcMRLSuaaleJk3Za6fA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715392140","token_type":"Bearer","instance_url":"https://<host>","signature":"bcg+FhBqe0ZyHpYd43tkTmXlDCi8iyF0A98BQ01cUaY=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:12 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801596206","token_type":"Bearer","instance_url":"https://<host>","signature":"2xMhdPCK5ZOXwI3QCEAK+ZV+ZzCuuaoz9d8/2UWeSNo=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:17 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:14 GMT
+      - Mon, 08 Jun 2015 22:13:16 GMT
       Set-Cookie:
-      - BrowserId=nW4xVu5zS8OVsvmDqd8qyQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:14 GMT
+      - BrowserId=ixlaNp37T0Wdi6vwDfg55g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/15000
+      - api-usage=90/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZN2AAM"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNcAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001yZN2AAM","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:14 GMT
+      string: '{"id":"0031a000004cfNcAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:18 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001yZN2AAM"}'
+      string: '{"Friend__c":"0031a000004cfNcAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:15 GMT
+      - Mon, 08 Jun 2015 22:13:16 GMT
       Set-Cookie:
-      - BrowserId=4T4jjRFBSP6daf4Qk0hLZQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:15 GMT
+      - BrowserId=va-gKnqvRQGnBEM6Jqa7RQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/15000
+      - api-usage=93/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7QAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgKAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:16 GMT
+      string: '{"id":"a001a000001cF7QAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7QAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:16 GMT
+      - Mon, 08 Jun 2015 22:13:16 GMT
       Set-Cookie:
-      - BrowserId=tLFbGtRnSt-8k-hKMrDtog;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:16 GMT
+      - BrowserId=SBUWYiQuRMmq__asxDovDg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/15000
+      - api-usage=93/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:17 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7QAAU"},"Id":"a001a000001cF7QAAU","SystemModstamp":"2015-06-08T22:13:16.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF7Q","Example_Field__c":null,"Friend__c":"0031a000004cfNcAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:18 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgKAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7QAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:17 GMT
+      - Mon, 08 Jun 2015 22:13:17 GMT
       Set-Cookie:
-      - BrowserId=32_mDTRRTD2DMwZ58IBL3w;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:17 GMT
+      - BrowserId=hm3YX4aOTDqqAHdoGJSQAw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/15000
+      - api-usage=91/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW"},"Id":"a001a000001LXgKAAW","SystemModstamp":"2015-04-11T01:23:15.000+0000","Name":"a001a000001LXgK","Example_Field__c":null,"Friend__c":"0031a000001yZN2AAM"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:18 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7QAAU"},"Id":"a001a000001cF7QAAU","SystemModstamp":"2015-06-08T22:13:16.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF7Q","Example_Field__c":null,"Friend__c":"0031a000004cfNcAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZN2AAM
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNcAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,10 +221,10 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:18 GMT
+      - Mon, 08 Jun 2015 22:13:17 GMT
       Set-Cookie:
-      - BrowserId=bM2066kCTMCnkZZZ4YvewA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:18 GMT
+      - BrowserId=YzySvmWCRC2aK4_9HnOW-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -232,11 +232,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgKAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7QAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:23:20 GMT
+      - Mon, 08 Jun 2015 22:13:17 GMT
       Set-Cookie:
-      - BrowserId=45Q39T1eTzmkDnRLr04BPg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:23:20 GMT
+      - BrowserId=LD2T-NKMTh2Bqo7dNep6Gg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=100/15000
+      - api-usage=91/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:23:20 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:19 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/builds_a_number_of_associated_records_from_the_data_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/builds_a_number_of_associated_records_from_the_data_in_Salesforce.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:52 GMT
+      - Mon, 08 Jun 2015 22:12:57 GMT
       Set-Cookie:
-      - BrowserId=SjnTW7F7RkKsIjaFmUtNzw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:52 GMT
+      - BrowserId=2UgMcOy2Sr25E8ZpRhUuVw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428634672541","token_type":"Bearer","instance_url":"https://<host>","signature":"+Yw0d+DUcrlkXfNTN9OldvMmsaQIzIfxRVOXzMBfzrA=","access_token":"00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW"}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:52 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801577306","token_type":"Bearer","instance_url":"https://<host>","signature":"d27iLcR4Ia/N2gQ99WKeVaEQypgvvH6LkFhYVNhUGEE=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:58 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:54 GMT
+      - Mon, 08 Jun 2015 22:12:57 GMT
       Set-Cookie:
-      - BrowserId=XSyg9Tt9SFqz-UswEKwn_Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:54 GMT
+      - BrowserId=vmazd7lMTqG4rYI8X7UjQg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/15000
+      - api-usage=42/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6SAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LS2dAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:54 GMT
+      string: '{"id":"a001a000001cF6SAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:59 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"First Detail","CustomObject__c":"a001a000001LS2dAAG"}'
+      string: '{"Name":"First Detail","CustomObject__c":"a001a000001cF6SAAU"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,38 +105,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:55 GMT
+      - Mon, 08 Jun 2015 22:12:57 GMT
       Set-Cookie:
-      - BrowserId=By4dF0JzTXCXJChaCwVarQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:55 GMT
+      - BrowserId=G-Tfx6Q2TdWjhpWIyHAvgQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/15000
+      - api-usage=38/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPnAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gvbNAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:55 GMT
+      string: '{"id":"a011a000001FiPnAAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:59 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001LS2dAAG"}'
+      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001cF6SAAU"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,38 +147,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:56 GMT
+      - Mon, 08 Jun 2015 22:12:57 GMT
       Set-Cookie:
-      - BrowserId=YVyXNj1hQrWqaahZ_coJ7g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:56 GMT
+      - BrowserId=fzkXjq3cQiScjt8W7yDyuQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:57 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/15000
+      - api-usage=36/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPsAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gvbSAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:57 GMT
+      string: '{"id":"a011a000001FiPsAAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:59 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001LS2dAAG"}'
+      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001cF6SAAU"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -189,28 +189,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:58 GMT
+      - Mon, 08 Jun 2015 22:12:58 GMT
       Set-Cookie:
-      - BrowserId=d6z2lNgkSf2up8MAXG1a6Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:58 GMT
+      - BrowserId=YyxQdIqRQLWep3KGIuREbw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/15000
+      - api-usage=41/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPZAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gvbXAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:58 GMT
+      string: '{"id":"a011a000001FiPZAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:59 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LS2dAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6SAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -229,27 +229,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:57:59 GMT
+      - Mon, 08 Jun 2015 22:12:58 GMT
       Set-Cookie:
-      - BrowserId=mWvixFNmSyqnCFC3TYDC0Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:57:59 GMT
+      - BrowserId=igFdiM33THu1k1jVaEwrqw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=48/15000
+      - api-usage=34/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG"},"Id":"a001a000001LS2dAAG","SystemModstamp":"2015-04-10T02:57:54.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6SAAU"},"Id":"a001a000001cF6SAAU","SystemModstamp":"2015-06-08T22:12:57.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:57:59 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:59 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LS2dAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF6SAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -257,7 +257,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -268,29 +268,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:58:00 GMT
+      - Mon, 08 Jun 2015 22:12:58 GMT
       Set-Cookie:
-      - BrowserId=0GN0ttrKSZavKAuYiSUqIg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:58:00 GMT
+      - BrowserId=jqV9_L29SR2FjM1_VVoTQw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/15000
+      - api-usage=41/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ"},"Id":"a011a000000gvbNAAQ","SystemModstamp":"2015-04-10T02:57:55.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ"},"Id":"a011a000000gvbXAAQ","SystemModstamp":"2015-04-10T02:57:58.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001LS2dAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ"},"Id":"a011a000000gvbSAAQ","SystemModstamp":"2015-04-10T02:57:57.000+0000","Name":"Second
-        Detail","CustomObject__c":"a001a000001LS2dAAG"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:58:00 GMT
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPsAAK"},"Id":"a011a000001FiPsAAK","SystemModstamp":"2015-06-08T22:12:57.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Second
+        Detail","CustomObject__c":"a001a000001cF6SAAU"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPZAA0"},"Id":"a011a000001FiPZAA0","SystemModstamp":"2015-06-08T22:12:58.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Third
+        Detail","CustomObject__c":"a001a000001cF6SAAU"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPnAAK"},"Id":"a011a000001FiPnAAK","SystemModstamp":"2015-06-08T22:12:57.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"First
+        Detail","CustomObject__c":"a001a000001cF6SAAU"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LS2dAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6SAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -298,7 +298,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -309,22 +309,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:58:01 GMT
+      - Mon, 08 Jun 2015 22:12:58 GMT
       Set-Cookie:
-      - BrowserId=s41Fi0P_T_iCPZZtp-9Efw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:58:01 GMT
+      - BrowserId=a3-VqHTsQTmohTV8dkIwUg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/15000
+      - api-usage=36/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:58:01 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbNAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPnAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -332,7 +332,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -343,14 +343,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:58:02 GMT
+      - Mon, 08 Jun 2015 22:12:58 GMT
       Set-Cookie:
-      - BrowserId=x1eXztaBSUWXeuLJMIuz_w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:58:02 GMT
+      - BrowserId=Jhp6om1BQ_aRLtCebUrnDg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:58 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/15000
+      - api-usage=40/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:58:03 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbSAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPsAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -370,7 +370,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -381,14 +381,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:58:04 GMT
+      - Mon, 08 Jun 2015 22:12:59 GMT
       Set-Cookie:
-      - BrowserId=c02nnlKQShmjP8RQBRaTGg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:58:04 GMT
+      - BrowserId=djg4GX5eSTKNsJGx-sL8bg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/15000
+      - api-usage=38/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:58:04 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gvbXAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPZAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -408,7 +408,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNe4R8V.LO2wVndhS1VuuxNtdXS1JCvyNPnzJvH6QSXO9uYDDviw_E1.9iDm2CAsI8PipNylFdpNxUnQrofmMfc7RNsW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -419,14 +419,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 10 Apr 2015 02:58:06 GMT
+      - Mon, 08 Jun 2015 22:12:59 GMT
       Set-Cookie:
-      - BrowserId=Wk4e4KfeSfKcHiSZ_G5ovw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 02:58:06 GMT
+      - BrowserId=3oYV6acjT_qk6_3tgSugRQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=49/15000
+      - api-usage=33/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 02:58:06 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:00 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:17:58 GMT
+      - Mon, 08 Jun 2015 22:13:29 GMT
       Set-Cookie:
-      - BrowserId=knvFN9iJTMKYpcGnHxGrNQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:17:58 GMT
+      - BrowserId=1a9newCsSPiK6__rbSLD9Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557478143","token_type":"Bearer","instance_url":"https://<host>","signature":"ra/+CwNB4ZgXs5e+MFICh3OTNXzz5U4pVS+WeaUDLAU=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:17:58 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801609426","token_type":"Bearer","instance_url":"https://<host>","signature":"/QY9zbU2tOc4bX4LSoY5RGsuEKciOH427F7dnJdkLMQ=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:30 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:17:59 GMT
+      - Mon, 08 Jun 2015 22:13:29 GMT
       Set-Cookie:
-      - BrowserId=JaVblvyiRQqfJcGVtSmJ4Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:17:59 GMT
+      - BrowserId=ylXFSnhCQrO2UIyG52DA2Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=126/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4DAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001MFzDAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:17:59 GMT
+      string: '{"id":"a001a000001cF4DAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:31 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001MFzDAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4DAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:18:00 GMT
+      - Mon, 08 Jun 2015 22:13:29 GMT
       Set-Cookie:
-      - BrowserId=0Ab5uTlGTL-VOz6fZeGBQQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:18:00 GMT
+      - BrowserId=M3m-mKA8SZCOtBeO9-8uow;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=131/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW"},"Id":"a001a000001MFzDAAW","SystemModstamp":"2015-04-20T19:17:59.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4DAAU"},"Id":"a001a000001cF4DAAU","SystemModstamp":"2015-06-08T22:13:29.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:18:00 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:31 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001MFzDAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF4DAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:18:01 GMT
+      - Mon, 08 Jun 2015 22:13:30 GMT
       Set-Cookie:
-      - BrowserId=UZsTVUtDRXy4NAO7ErcPVQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:18:01 GMT
+      - BrowserId=rt0WnLd8Q-uXKx28kjmq9g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=128/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -157,11 +157,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:18:01 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:31 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001MFzDAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4DAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -169,7 +169,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -180,17 +180,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:18:02 GMT
+      - Mon, 08 Jun 2015 22:13:30 GMT
       Set-Cookie:
-      - BrowserId=t4MT5NpQS2Cm_VnlJC0gag;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:18:02 GMT
+      - BrowserId=HR8AoqNITxuCEkNsLzillw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=136/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:18:02 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:31 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_alrady_been_persisted/constructs_the_association_from_the_existing_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_alrady_been_persisted/constructs_the_association_from_the_existing_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:22 GMT
+      - Mon, 08 Jun 2015 22:13:18 GMT
       Set-Cookie:
-      - BrowserId=auDO3L3YTRG8WSDHPuQ0iw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:22 GMT
+      - BrowserId=WSbuxYHKQISF8AxVDprbbw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429810822356","token_type":"Bearer","instance_url":"https://<host>","signature":"KsYGkglGxb+rYOwCQ8vWPs/HDGolddk5RrRN6T/WDMw=","access_token":"00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l"}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:22 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801599030","token_type":"Bearer","instance_url":"https://<host>","signature":"FHHPdxPRRW7n4qK7lpAwlKjjdYYuGl0PaPTlYxKmBI4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:20 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:23 GMT
+      - Mon, 08 Jun 2015 22:13:19 GMT
       Set-Cookie:
-      - BrowserId=q4gcxGiaTImoiTiEk64vWg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:23 GMT
+      - BrowserId=9zOo7scDSFu2SsxNNDPdtw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=19/15000
+      - api-usage=95/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7aAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001QmhvAAC","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:23 GMT
+      string: '{"id":"a001a000001cF7aAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:20 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"First Detail","CustomObject__c":"a001a000001QmhvAAC"}'
+      string: '{"Name":"First Detail","CustomObject__c":"a001a000001cF7aAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,38 +105,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:24 GMT
+      - Mon, 08 Jun 2015 22:13:19 GMT
       Set-Cookie:
-      - BrowserId=Lyq4m6PWQ7WP9iSDbCtosA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:24 GMT
+      - BrowserId=TObvZISiSI2Fx5APzTxZHw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=19/15000
+      - api-usage=94/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQHAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000i200AAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:25 GMT
+      string: '{"id":"a011a000001FiQHAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:21 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001QmhvAAC"}'
+      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001cF7aAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,38 +147,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:26 GMT
+      - Mon, 08 Jun 2015 22:13:19 GMT
       Set-Cookie:
-      - BrowserId=u05ioveESM26NdjEyXuk-w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:26 GMT
+      - BrowserId=SyQYhUk4SeKFl8nzlmeLWw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=19/15000
+      - api-usage=97/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQMAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000i205AAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:26 GMT
+      string: '{"id":"a011a000001FiQMAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:21 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001QmhvAAC"}'
+      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001cF7aAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -189,28 +189,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:27 GMT
+      - Mon, 08 Jun 2015 22:13:19 GMT
       Set-Cookie:
-      - BrowserId=ZXpSJyVhRo6RY4yKsLZFFg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:27 GMT
+      - BrowserId=kh0Y0mM4SXSZP1tHKXxOKA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/15000
+      - api-usage=100/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQRAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000i20AAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:27 GMT
+      string: '{"id":"a011a000001FiQRAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001QmhvAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7aAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -229,27 +229,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:28 GMT
+      - Mon, 08 Jun 2015 22:13:20 GMT
       Set-Cookie:
-      - BrowserId=p4RqG89-SJicgPP_svy3hA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:28 GMT
+      - BrowserId=xo0ToImJR9Gq8Ee8pSWPWg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=19/15000
+      - api-usage=99/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC"},"Id":"a001a000001QmhvAAC","SystemModstamp":"2015-04-23T17:40:23.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7aAAE"},"Id":"a001a000001cF7aAAE","SystemModstamp":"2015-06-08T22:13:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:28 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001QmhvAAC%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF7aAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -257,7 +257,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -268,29 +268,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:29 GMT
+      - Mon, 08 Jun 2015 22:13:20 GMT
       Set-Cookie:
-      - BrowserId=8JtfCZh8RZ-FCVG0P_xZ8w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:29 GMT
+      - BrowserId=sZr0iPH5Q6aDWF-7DPa55g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/15000
+      - api-usage=102/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA"},"Id":"a011a000000i200AAA","SystemModstamp":"2015-04-23T17:40:24.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ"},"Id":"a011a000000i20AAAQ","SystemModstamp":"2015-04-23T17:40:27.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001QmhvAAC"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA"},"Id":"a011a000000i205AAA","SystemModstamp":"2015-04-23T17:40:26.000+0000","Name":"Second
-        Detail","CustomObject__c":"a001a000001QmhvAAC"}]}'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:29 GMT
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQRAA0"},"Id":"a011a000001FiQRAA0","SystemModstamp":"2015-06-08T22:13:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Third
+        Detail","CustomObject__c":"a001a000001cF7aAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQMAA0"},"Id":"a011a000001FiQMAA0","SystemModstamp":"2015-06-08T22:13:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Second
+        Detail","CustomObject__c":"a001a000001cF7aAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQHAA0"},"Id":"a011a000001FiQHAA0","SystemModstamp":"2015-06-08T22:13:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"First
+        Detail","CustomObject__c":"a001a000001cF7aAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:21 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001QmhvAAC
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7aAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -298,7 +298,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -309,22 +309,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:30 GMT
+      - Mon, 08 Jun 2015 22:13:20 GMT
       Set-Cookie:
-      - BrowserId=__i_R2k2QCGsGUPDu1OS6Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:30 GMT
+      - BrowserId=AQ9GAhEOS0OBejScOcNyKg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=22/15000
+      - api-usage=100/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:30 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:22 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i200AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQHAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -332,7 +332,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -343,14 +343,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:31 GMT
+      - Mon, 08 Jun 2015 22:13:20 GMT
       Set-Cookie:
-      - BrowserId=sFd3_6F9Q4iqOcFFD8T1_g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:31 GMT
+      - BrowserId=8m4bP-JTSa2-ZFd09j4IMg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/15000
+      - api-usage=101/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:31 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:22 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i205AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQMAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -370,7 +370,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -381,14 +381,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:32 GMT
+      - Mon, 08 Jun 2015 22:13:21 GMT
       Set-Cookie:
-      - BrowserId=wMQ3DDSySk-NgwSt3MztcA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:32 GMT
+      - BrowserId=AZUGwXylSZS9N6-7k_h5yA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/15000
+      - api-usage=108/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:32 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:22 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000i20AAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQRAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -408,7 +408,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFoglftCDJPkzXd0wAZ6dnUwrMZEyIrpgn8BUhjwsElswNHT_M5IOJSysNJCZXw6QPBjjHcAYLoUX8bFjnXkaUCdvO1l
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -419,14 +419,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 23 Apr 2015 17:40:33 GMT
+      - Mon, 08 Jun 2015 22:13:21 GMT
       Set-Cookie:
-      - BrowserId=14kb5QwbTyCwnia4w6iDyA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        22-Jun-2015 17:40:33 GMT
+      - BrowserId=N6XCxGnsTsaiBc9bOvRzaA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=20/15000
+      - api-usage=103/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Thu, 23 Apr 2015 17:40:33 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:22 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_been_cached/uses_the_cached_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_associated_records_have_been_cached/uses_the_cached_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:26 GMT
+      - Mon, 08 Jun 2015 22:13:04 GMT
       Set-Cookie:
-      - BrowserId=ib4ON7VzRoqYgNaKp0nkDQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:26 GMT
+      - BrowserId=dUu-f-O8TNyHhCILsSACaA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430497646270","token_type":"Bearer","instance_url":"https://<host>","signature":"fJPCXmLPScmZ35fJC8zeUl/q4GP4NMEjirHl+vGtLcs=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:26 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801584735","token_type":"Bearer","instance_url":"https://<host>","signature":"hFKMQqAuDfzuF3QCb5m3RWou9ETE2chBnFaOqykja/U=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:06 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:26 GMT
+      - Mon, 08 Jun 2015 22:13:04 GMT
       Set-Cookie:
-      - BrowserId=K6OcPnUIRReOx5pwcCgBYw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:26 GMT
+      - BrowserId=9bdusYb9R56HTrD3xIQW1g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=51/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6rAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001TuOxAAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:27 GMT
+      string: '{"id":"a001a000001cF6rAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:06 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"First Detail","CustomObject__c":"a001a000001TuOxAAK"}'
+      string: '{"Name":"First Detail","CustomObject__c":"a001a000001cF6rAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,38 +105,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:27 GMT
+      - Mon, 08 Jun 2015 22:13:05 GMT
       Set-Cookie:
-      - BrowserId=gpF3gRK9TV2R-D1SseMfTQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:27 GMT
+      - BrowserId=9vPn7OZVR9a9fp_pBHmg1w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=52/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ2AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000ikfZAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:27 GMT
+      string: '{"id":"a011a000001FiQ2AAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:06 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001TuOxAAK"}'
+      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001cF6rAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,38 +147,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:27 GMT
+      - Mon, 08 Jun 2015 22:13:05 GMT
       Set-Cookie:
-      - BrowserId=QMTsOUBZS_K8SISTgD5b2A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:27 GMT
+      - BrowserId=tv400Na9TDa-pZzwYhFuCw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=46/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ7AAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000ikfeAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:27 GMT
+      string: '{"id":"a011a000001FiQ7AAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:06 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001TuOxAAK"}'
+      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001cF6rAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -189,28 +189,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:27 GMT
+      - Mon, 08 Jun 2015 22:13:05 GMT
       Set-Cookie:
-      - BrowserId=ALmi5ZflT0OzU7ADg50byw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:27 GMT
+      - BrowserId=6PpnXPBrTyWtIxLiqlc8aA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=49/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQCAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000ikfjAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:28 GMT
+      string: '{"id":"a011a000001FiQCAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:07 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001TuOxAAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6rAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -229,27 +229,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:27 GMT
+      - Mon, 08 Jun 2015 22:13:05 GMT
       Set-Cookie:
-      - BrowserId=jc3wCYrbQxapLeo0TDaP5g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:27 GMT
+      - BrowserId=P2EQ_6gSQbiITczndAY9dA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=50/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK"},"Id":"a001a000001TuOxAAK","SystemModstamp":"2015-05-01T16:27:26.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6rAAE"},"Id":"a001a000001cF6rAAE","SystemModstamp":"2015-06-08T22:13:04.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:28 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:07 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001TuOxAAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF6rAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -257,7 +257,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -268,29 +268,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:28 GMT
+      - Mon, 08 Jun 2015 22:13:05 GMT
       Set-Cookie:
-      - BrowserId=2fxroKOLSO-Iaj7oU9I5-g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:28 GMT
+      - BrowserId=s8nN19bqRJqJy2W98lR7AA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:05 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=53/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA"},"Id":"a011a000000ikfjAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ"},"Id":"a011a000000ikfZAAQ","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001TuOxAAK"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA"},"Id":"a011a000000ikfeAAA","SystemModstamp":"2015-05-01T16:27:27.000+0000","Name":"Second
-        Detail","CustomObject__c":"a001a000001TuOxAAK"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:28 GMT
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ2AAK"},"Id":"a011a000001FiQ2AAK","SystemModstamp":"2015-06-08T22:13:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"First
+        Detail","CustomObject__c":"a001a000001cF6rAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQCAA0"},"Id":"a011a000001FiQCAA0","SystemModstamp":"2015-06-08T22:13:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Third
+        Detail","CustomObject__c":"a001a000001cF6rAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ7AAK"},"Id":"a011a000001FiQ7AAK","SystemModstamp":"2015-06-08T22:13:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Second
+        Detail","CustomObject__c":"a001a000001cF6rAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuOxAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6rAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -298,7 +298,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -309,22 +309,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:28 GMT
+      - Mon, 08 Jun 2015 22:13:06 GMT
       Set-Cookie:
-      - BrowserId=dKopFlNeTMCogPnX1C0JYg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:28 GMT
+      - BrowserId=UIDofruvTBSQ2zNyK8avDA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=61/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:29 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfZAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ2AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -332,7 +332,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -343,14 +343,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:29 GMT
+      - Mon, 08 Jun 2015 22:13:06 GMT
       Set-Cookie:
-      - BrowserId=MAQYa6aKSFqS00iE6W2JoQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:29 GMT
+      - BrowserId=3JNUrqu7RC2eI1hslvTMLg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=50/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:29 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:07 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfeAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQ7AAK
     body:
       encoding: US-ASCII
       string: ''
@@ -370,7 +370,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -381,14 +381,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:29 GMT
+      - Mon, 08 Jun 2015 22:13:06 GMT
       Set-Cookie:
-      - BrowserId=1nbJRhPrR36jKWIobb0Zxw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:29 GMT
+      - BrowserId=caaNbcdsQRWJJquxT8odcg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=54/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:29 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:08 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000ikfjAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQCAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -408,7 +408,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -419,14 +419,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Fri, 01 May 2015 16:27:29 GMT
+      - Mon, 08 Jun 2015 22:13:06 GMT
       Set-Cookie:
-      - BrowserId=6NzebkrwTee870YTkR0yuw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:27:29 GMT
+      - BrowserId=FrzYgMdwSDKyoq6sievPXQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=63/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:27:29 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:08 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:56:59 GMT
+      - Mon, 08 Jun 2015 22:13:15 GMT
       Set-Cookie:
-      - BrowserId=yusXRkc8QSyB7IvrQnLLOA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:56:59 GMT
+      - BrowserId=VT78DtH2RXSvFOu9vzt9Jg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460619986","token_type":"Bearer","instance_url":"https://<host>","signature":"u64BZdZBkpV7s2sYs1cc+mLttOxfG+RQh+VA+afErCc=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:56:59 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801595312","token_type":"Bearer","instance_url":"https://<host>","signature":"Ki1z0iIcgKcFIhkRKP2g4+I6FRrPEGSHnXnGcHNeN+4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:16 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:00 GMT
+      - Mon, 08 Jun 2015 22:13:15 GMT
       Set-Cookie:
-      - BrowserId=czn8MSKAQYCWpily8DabbA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:00 GMT
+      - BrowserId=zWTfuSHXTzuEG6G9ZEEiZQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=91/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7LAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZKK3AAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:01 GMT
+      string: '{"id":"a001a000001cF7LAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZKK3AAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7LAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:02 GMT
+      - Mon, 08 Jun 2015 22:13:15 GMT
       Set-Cookie:
-      - BrowserId=iG1exjXpRjOfCoOwN3IvHw;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:02 GMT
+      - BrowserId=miI2uehgSziegsNOs8wreg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=100/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO"},"Id":"a001a000001ZKK3AAO","SystemModstamp":"2015-05-12T19:57:01.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7LAAU"},"Id":"a001a000001cF7LAAU","SystemModstamp":"2015-06-08T22:13:15.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:02 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:17 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK3AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7LAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:03 GMT
+      - Mon, 08 Jun 2015 22:13:15 GMT
       Set-Cookie:
-      - BrowserId=zPNjjlJwT5y6BR4og2QjtA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:03 GMT
+      - BrowserId=orG58TguQfi6jJzPvEoJGw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=99/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:03 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:17 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:45 GMT
+      - Mon, 08 Jun 2015 22:12:08 GMT
       Set-Cookie:
-      - BrowserId=VV_spkQdR8qubm0JpfTtbw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:45 GMT
+      - BrowserId=d0QpJhNkTgaNsW-k4xL3XQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715785563","token_type":"Bearer","instance_url":"https://<host>","signature":"CP3JKuG7/SQHR4Dam1HfpVtvW2QDAn8O0aTFO+2REEg=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:46 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801528187","token_type":"Bearer","instance_url":"https://<host>","signature":"rBxYmXgPQcB55pphZb1eue9NmpK1TjeeqXy9z0UwwIM=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:09 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:46 GMT
+      - Mon, 08 Jun 2015 22:12:08 GMT
       Set-Cookie:
-      - BrowserId=aInJO_P6S9CgPQAJiPLQOg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:46 GMT
+      - BrowserId=cxk5xxssRuOLf9AeJHn_sw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF3xAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgyAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:47 GMT
+      string: '{"id":"a001a000001cF3xAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:09 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"First Detail","CustomObject__c":"a001a000001LXgyAAG"}'
+      string: '{"Name":"First Detail","CustomObject__c":"a001a000001cF3xAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,38 +105,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:47 GMT
+      - Mon, 08 Jun 2015 22:12:08 GMT
       Set-Cookie:
-      - BrowserId=8OuxrYcMSci9f5ucAA61Ow;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:47 GMT
+      - BrowserId=CQi9eeBlTG-TTTNGWr4amw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPOAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gym7AAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:48 GMT
+      string: '{"id":"a011a000001FiPOAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:10 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001LXgyAAG"}'
+      string: '{"Name":"Second Detail","CustomObject__c":"a001a000001cF3xAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,38 +147,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:48 GMT
+      - Mon, 08 Jun 2015 22:12:08 GMT
       Set-Cookie:
-      - BrowserId=gqy-MunDTHSeKeiSBBS5Sg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:48 GMT
+      - BrowserId=ZZpIzxzBTYqNiV3zK-EjIg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:08 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPTAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gylUAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:49 GMT
+      string: '{"id":"a011a000001FiPTAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:10 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001LXgyAAG"}'
+      string: '{"Name":"Third Detail","CustomObject__c":"a001a000001cF3xAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -189,28 +189,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:49 GMT
+      - Mon, 08 Jun 2015 22:12:09 GMT
       Set-Cookie:
-      - BrowserId=eVURrnNBQvqY48EHi_z8ZQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:49 GMT
+      - BrowserId=b53z30RTRmivcmz9vrzTPw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPYAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gymCAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:50 GMT
+      string: '{"id":"a011a000001FiPYAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:10 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXgyAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF3xAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -218,7 +218,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -229,27 +229,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:50 GMT
+      - Mon, 08 Jun 2015 22:12:09 GMT
       Set-Cookie:
-      - BrowserId=ZhSDIpJlR1SlGlsJOOCO5w;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:50 GMT
+      - BrowserId=f0Ch4DcaSRWniqVL_8HA5g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG"},"Id":"a001a000001LXgyAAG","SystemModstamp":"2015-04-11T01:29:46.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF3xAAE"},"Id":"a001a000001cF3xAAE","SystemModstamp":"2015-06-08T22:12:08.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:51 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:10 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXgyAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF3xAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -257,7 +257,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -268,29 +268,29 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:51 GMT
+      - Mon, 08 Jun 2015 22:12:09 GMT
       Set-Cookie:
-      - BrowserId=TPsGnc-QRp6JWQdNY6H7nw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:51 GMT
+      - BrowserId=GSNSBCefRaqhcDvtOnIm_Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ"},"Id":"a011a000000gylUAAQ","SystemModstamp":"2015-04-11T01:29:48.000+0000","Name":"Second
-        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA"},"Id":"a011a000000gym7AAA","SystemModstamp":"2015-04-11T01:29:47.000+0000","Name":"First
-        Detail","CustomObject__c":"a001a000001LXgyAAG"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ"},"Id":"a011a000000gymCAAQ","SystemModstamp":"2015-04-11T01:29:49.000+0000","Name":"Third
-        Detail","CustomObject__c":"a001a000001LXgyAAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:52 GMT
+      string: '{"totalSize":3,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPOAA0"},"Id":"a011a000001FiPOAA0","SystemModstamp":"2015-06-08T22:12:08.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"First
+        Detail","CustomObject__c":"a001a000001cF3xAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPYAA0"},"Id":"a011a000001FiPYAA0","SystemModstamp":"2015-06-08T22:12:09.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Third
+        Detail","CustomObject__c":"a001a000001cF3xAAE"},{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPTAA0"},"Id":"a011a000001FiPTAA0","SystemModstamp":"2015-06-08T22:12:08.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Second
+        Detail","CustomObject__c":"a001a000001cF3xAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgyAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF3xAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -298,7 +298,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -309,22 +309,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:52 GMT
+      - Mon, 08 Jun 2015 22:12:09 GMT
       Set-Cookie:
-      - BrowserId=GPOLOtEhRjOj-ZQI9VhL_A;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:52 GMT
+      - BrowserId=eZVKUi0GRKagIpQz802ZRQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:53 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gym7AAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPOAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -332,7 +332,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -343,14 +343,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:53 GMT
+      - Mon, 08 Jun 2015 22:12:09 GMT
       Set-Cookie:
-      - BrowserId=X2FYj_rwQ46ZEYVmd34Ehg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:53 GMT
+      - BrowserId=Dp-zDpkBQ9CFsqkk8amcpQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:09 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -358,11 +358,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:54 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gylUAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPTAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -370,7 +370,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -381,14 +381,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:54 GMT
+      - Mon, 08 Jun 2015 22:12:10 GMT
       Set-Cookie:
-      - BrowserId=0F4dFZ8OT_i3EZx6ySX99w;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:54 GMT
+      - BrowserId=zGSIONIeT0KJCfZUJ3PLsg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -396,11 +396,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:55 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:11 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gymCAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPYAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -408,7 +408,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -419,14 +419,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:56 GMT
+      - Mon, 08 Jun 2015 22:12:10 GMT
       Set-Cookie:
-      - BrowserId=fa1WPMDhTqGrd6tI4KrzYQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:56 GMT
+      - BrowserId=XgiF9JpjQl2HbEjKaXVgCg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=5/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -434,6 +434,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:57 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:11 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasMany/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:29:58 GMT
+      - Mon, 08 Jun 2015 22:13:13 GMT
       Set-Cookie:
-      - BrowserId=x8CKG8j8THSZV7DpEsVLIg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:29:58 GMT
+      - BrowserId=-L93PRXwTtGOR7MwxR0BXg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715798755","token_type":"Bearer","instance_url":"https://<host>","signature":"/GkLEgWKmoxA2MrX0e/J3mV+I37ybalQOsRqYmS4YNU=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:29:59 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801593109","token_type":"Bearer","instance_url":"https://<host>","signature":"Vj64TUOB1faBoixyHkorG5NV1hfd6SH+SZUcTrWKnAw=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:14 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:30:00 GMT
+      - Mon, 08 Jun 2015 22:13:13 GMT
       Set-Cookie:
-      - BrowserId=SIzfsqgLTa-jNKJO1wgXvg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:30:00 GMT
+      - BrowserId=tQ3Qkx9GQpeH20jOR_-bCA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=170/15000
+      - api-usage=79/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4wAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXh3AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:30:00 GMT
+      string: '{"id":"a001a000001cF4wAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:14 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXh3AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4wAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:30:01 GMT
+      - Mon, 08 Jun 2015 22:13:13 GMT
       Set-Cookie:
-      - BrowserId=CfhnKykHQ_edY1rlPQpe0Q;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:30:01 GMT
+      - BrowserId=AnmlGHWpRhOZnAnQj_oX7A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=171/15000
+      - api-usage=79/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG"},"Id":"a001a000001LXh3AAG","SystemModstamp":"2015-04-11T01:30:00.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4wAAE"},"Id":"a001a000001cF4wAAE","SystemModstamp":"2015-06-08T22:13:13.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:30:01 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:15 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LXh3AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF4wAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:30:02 GMT
+      - Mon, 08 Jun 2015 22:13:13 GMT
       Set-Cookie:
-      - BrowserId=M9SJMGIaRbKLVv1KPQho5Q;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:30:02 GMT
+      - BrowserId=joSsKpECSbe29CrpNZLtag;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=172/15000
+      - api-usage=80/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -157,11 +157,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:30:02 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:15 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXh3AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4wAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -169,7 +169,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -180,17 +180,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:30:03 GMT
+      - Mon, 08 Jun 2015 22:13:13 GMT
       Set-Cookie:
-      - BrowserId=henkCHXOSQyr7R2BuqP8cQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:30:03 GMT
+      - BrowserId=NI5_1H5_Q8K9E_n32GH8Hg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:13 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=171/15000
+      - api-usage=81/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:30:03 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:15 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/and_a_nested_association_on_the_associated_mapping/recursively_builds_all_associations.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/and_a_nested_association_on_the_associated_mapping/recursively_builds_all_associations.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:25:59 GMT
+      - Mon, 08 Jun 2015 22:13:27 GMT
       Set-Cookie:
-      - BrowserId=wRO9AsU-SU6xl-dn4F8y0w;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:25:59 GMT
+      - BrowserId=yY_zEOLQRdiHuOD8eMKgRQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429212359162","token_type":"Bearer","instance_url":"https://<host>","signature":"GigH5zHmZ1IsG+SaU0QdxmWhrvcKdrCm9X2rf1EkiwM=","access_token":"00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q"}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:25:58 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801607082","token_type":"Bearer","instance_url":"https://<host>","signature":"EUELGd/eVWoqMkVCH/dtKXDy+TGDtkos/P4p5U/+QLw=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:28 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:00 GMT
+      - Mon, 08 Jun 2015 22:13:27 GMT
       Set-Cookie:
-      - BrowserId=tRsiGzYzSMyKS0RqJbPpCw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:00 GMT
+      - BrowserId=1uUU09DwRT-2oqwQUtnxww;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=133/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNhAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002JQEpAAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:00 GMT
+      string: '{"id":"0031a000004cfNhAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:28 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002JQEpAAO"}'
+      string: '{"Friend__c":"0031a000004cfNhAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,38 +105,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:01 GMT
+      - Mon, 08 Jun 2015 22:13:27 GMT
       Set-Cookie:
-      - BrowserId=y52TPTAuRN6fW06z37GcTQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:01 GMT
+      - BrowserId=6WKYBwzlQAmK-hVPgn6tHA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=129/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7uAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LoG1AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:01 GMT
+      string: '{"id":"a001a000001cF7uAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:29 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"CustomObject__c":"a001a000001LoG1AAK"}'
+      string: '{"CustomObject__c":"a001a000001cF7uAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,28 +147,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:02 GMT
+      - Mon, 08 Jun 2015 22:13:27 GMT
       Set-Cookie:
-      - BrowserId=cOGQueDpQNSZiHpqWIIf-g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:02 GMT
+      - BrowserId=Z3qYrSXqRJm94ibgYqp2qA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=131/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQWAA0"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000hKfnAAE","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:02 GMT
+      string: '{"id":"a011a000001FiQWAA0","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:29 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002JQEpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfNhAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -187,26 +187,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:03 GMT
+      - Mon, 08 Jun 2015 22:13:27 GMT
       Set-Cookie:
-      - BrowserId=7tPGpHZJQguC6IxoBKUgaw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:03 GMT
+      - BrowserId=YxeFc543QH2Bym85U6MMxw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=126/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO"},"Id":"0031a000002JQEpAAO","SystemModstamp":"2015-04-16T19:26:00.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:03 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfNhAAI"},"Id":"0031a000004cfNhAAI","SystemModstamp":"2015-06-08T22:13:27.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:29 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002JQEpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfNhAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -214,7 +214,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -225,26 +225,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:04 GMT
+      - Mon, 08 Jun 2015 22:13:28 GMT
       Set-Cookie:
-      - BrowserId=0GBZp5d6Q4W9oYJ2xCoqPA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:04 GMT
+      - BrowserId=qXxniYoqQ6KKrr64XeXhgw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=127/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK"},"Id":"a001a000001LoG1AAK","SystemModstamp":"2015-04-16T19:26:01.000+0000","Name":"a001a000001LoG1","Example_Field__c":null,"Friend__c":"0031a000002JQEpAAO"}]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:04 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7uAAE"},"Id":"a001a000001cF7uAAE","SystemModstamp":"2015-06-08T22:13:27.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF7u","Example_Field__c":null,"Friend__c":"0031a000004cfNhAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:29 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001LoG1AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20CustomObject__c%20=%20%27a001a000001cF7uAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -252,7 +252,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -263,26 +263,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:05 GMT
+      - Mon, 08 Jun 2015 22:13:28 GMT
       Set-Cookie:
-      - BrowserId=RScD8n0tQn6Ka40Q_zj2pw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:05 GMT
+      - BrowserId=CLtmCyvxS9aADgQnwiBJCg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=134/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE"},"Id":"a011a000000hKfnAAE","SystemModstamp":"2015-04-16T19:26:02.000+0000","Name":"a011a000000hKfn","CustomObject__c":"a001a000001LoG1AAK"}]}'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:05 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQWAA0"},"Id":"a011a000001FiQWAA0","SystemModstamp":"2015-06-08T22:13:27.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiQW","CustomObject__c":"a001a000001cF7uAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:29 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002JQEpAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNhAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -290,7 +290,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -301,22 +301,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:06 GMT
+      - Mon, 08 Jun 2015 22:13:28 GMT
       Set-Cookie:
-      - BrowserId=NEH4ouAkSbmwL7ARdAXr7Q;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:06 GMT
+      - BrowserId=G5v-3CXQQLSqlngwGsL5KA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/15000
+      - api-usage=126/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:07 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:30 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LoG1AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7uAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -324,7 +324,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -335,22 +335,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:08 GMT
+      - Mon, 08 Jun 2015 22:13:28 GMT
       Set-Cookie:
-      - BrowserId=JR1qDjLqR9Kbaw5KhQpGjA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:08 GMT
+      - BrowserId=DTOZiIdBT7WxJ-VNjKNg3w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/15000
+      - api-usage=124/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:08 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:30 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000hKfnAAE
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQWAA0
     body:
       encoding: US-ASCII
       string: ''
@@ -358,7 +358,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPSOXZt5DLhfr69D_LCpoJzz_hcsgL5M3__5XXvOQMahZ5HtzzBveYd9BpdCGejgkgFYX6_ZfJkTvkaXqAWbAEpg555q
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -369,14 +369,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Thu, 16 Apr 2015 19:26:09 GMT
+      - Mon, 08 Jun 2015 22:13:29 GMT
       Set-Cookie:
-      - BrowserId=W0ivBZ6NTiSQA8J2bL7lgw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        15-Jun-2015 19:26:09 GMT
+      - BrowserId=SW8n-6iXSP-At3_-z3AYNQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=4/15000
+      - api-usage=125/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -384,6 +384,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Thu, 16 Apr 2015 19:26:09 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:30 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/returns_an_associated_record_populated_with_the_Salesforce_attributes.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:53 GMT
+      - Mon, 08 Jun 2015 22:12:24 GMT
       Set-Cookie:
-      - BrowserId=4dj_QA9WRg6K4WdMIIr2gQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:53 GMT
+      - BrowserId=tcP_iUwiRV66awgRN51ahg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428694613574","token_type":"Bearer","instance_url":"https://<host>","signature":"kgBP47lDsnoj+9xAXQq93nEJXbBT/5IPiHiIdQBA9W4=","access_token":"00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ"}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:53 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801544415","token_type":"Bearer","instance_url":"https://<host>","signature":"ZRHYtXteA2bF0HgIq7HZPZQ38c2koZmCWUk2oDYONp0=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:25 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:53 GMT
+      - Mon, 08 Jun 2015 22:12:24 GMT
       Set-Cookie:
-      - BrowserId=8co6OassRYmyO0-CTwBwWw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:53 GMT
+      - BrowserId=RWMhAbhjQWuDZfWL4NB_Dg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMUAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001yUpDAAU","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
+      string: '{"id":"0031a000004cfMUAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:26 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001yUpDAAU"}'
+      string: '{"Friend__c":"0031a000004cfMUAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:53 GMT
+      - Mon, 08 Jun 2015 22:12:24 GMT
       Set-Cookie:
-      - BrowserId=aIcTxYj6Td2WAcdkRtcHLQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:53 GMT
+      - BrowserId=Txdiz-eySIuprhpoOkVRrA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/15000
+      - api-usage=7/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4qAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXL8AAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
+      string: '{"id":"a001a000001cF4qAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:26 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yUpDAAU%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMUAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:54 GMT
+      - Mon, 08 Jun 2015 22:12:25 GMT
       Set-Cookie:
-      - BrowserId=UNYNMvZfTdmmnAn9IVi_Kw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:54 GMT
+      - BrowserId=v9e1srJ4Sna3-OS6gVn5yg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/15000
+      - api-usage=9/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU"},"Id":"0031a000001yUpDAAU","SystemModstamp":"2015-04-10T19:36:53.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMUAAY"},"Id":"0031a000004cfMUAAY","SystemModstamp":"2015-06-08T22:12:24.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:26 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yUpDAAU%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfMUAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:54 GMT
+      - Mon, 08 Jun 2015 22:12:25 GMT
       Set-Cookie:
-      - BrowserId=mQRACVKhQ5Ca96qGwNOM_g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:54 GMT
+      - BrowserId=THeDBND2ScW2bQgvCy_OaQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/15000
+      - api-usage=9/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO"},"Id":"a001a000001LXL8AAO","SystemModstamp":"2015-04-10T19:36:54.000+0000","Name":"a001a000001LXL8","Example_Field__c":null,"Friend__c":"0031a000001yUpDAAU"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:54 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4qAAE"},"Id":"a001a000001cF4qAAE","SystemModstamp":"2015-06-08T22:12:24.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF4q","Example_Field__c":null,"Friend__c":"0031a000004cfMUAAY"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:26 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yUpDAAU
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMUAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:54 GMT
+      - Mon, 08 Jun 2015 22:12:25 GMT
       Set-Cookie:
-      - BrowserId=BL-dqAy3TlKOqauzRtoqeQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:54 GMT
+      - BrowserId=f519hWlpRUuR9hZ-7GFVMw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=64/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:55 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXL8AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4qAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 19:36:54 GMT
+      - Mon, 08 Jun 2015 22:12:25 GMT
       Set-Cookie:
-      - BrowserId=ZmuPFZI4ReCEeB4LocND4Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 19:36:54 GMT
+      - BrowserId=AFpXgvhuTf6RQMG1aDvDoQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:25 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=63/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 19:36:55 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_no_salesforce_record_is_found_for_the_association/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:15:45 GMT
+      - Mon, 08 Jun 2015 22:12:48 GMT
       Set-Cookie:
-      - BrowserId=fyl77n8ITN2XO6RXSYfNwQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:15:45 GMT
+      - BrowserId=itdtGxN8QcaRdaR5Od8cPQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1429557345288","token_type":"Bearer","instance_url":"https://<host>","signature":"KWVtlhIqzN6OZ3uEXDa7ZakPVzRL4UeHWNXC7QKJacs=","access_token":"00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP"}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:15:45 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801568175","token_type":"Bearer","instance_url":"https://<host>","signature":"nwsRNRETjDYQHa2FOQSYH5kKEqvRTnPa4nPVzMakyw8=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:49 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:15:46 GMT
+      - Mon, 08 Jun 2015 22:12:48 GMT
       Set-Cookie:
-      - BrowserId=ouOxeCEtQlygBOZMsZkTqQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:15:46 GMT
+      - BrowserId=JtD2j-8CRIq1oU36D0emXg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=29/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfN4AAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002bvGPAAY","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:15:46 GMT
+      string: '{"id":"0031a000004cfN4AAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:49 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002bvGPAAY%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfN4AAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,26 +103,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:15:47 GMT
+      - Mon, 08 Jun 2015 22:12:48 GMT
       Set-Cookie:
-      - BrowserId=L-qnfxHxQT-0giWwEiWxLQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:15:47 GMT
+      - BrowserId=d6Htp5qfTbO9jRJ606lX8Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=23/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY"},"Id":"0031a000002bvGPAAY","SystemModstamp":"2015-04-20T19:15:46.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:15:47 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfN4AAI"},"Id":"0031a000004cfN4AAI","SystemModstamp":"2015-06-08T22:12:48.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:50 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002bvGPAAY%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfN4AAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -130,7 +130,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -141,14 +141,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:15:48 GMT
+      - Mon, 08 Jun 2015 22:12:48 GMT
       Set-Cookie:
-      - BrowserId=T1KkYnY3SHmnBUDVocLZxA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:15:48 GMT
+      - BrowserId=5pcE8w-vRa6Zh2FU8NdLAA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=27/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -156,11 +156,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:15:49 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:50 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002bvGPAAY
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfN4AAI
     body:
       encoding: US-ASCII
       string: ''
@@ -168,7 +168,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQJoC69lofp3.BkQNHdxEquIbjgARO_AQ3LgRth6RSFmB4_KVDLfm9_.J64ouFAGqhXyiThQHypNf.xCD1enx2SQbZDcP
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -179,17 +179,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 20 Apr 2015 19:15:49 GMT
+      - Mon, 08 Jun 2015 22:12:48 GMT
       Set-Cookie:
-      - BrowserId=zs9JsBwzTSuxXfkH1xTs0g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        19-Jun-2015 19:15:49 GMT
+      - BrowserId=G0aW5FUySz60XZs-aT6jlQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:48 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=27/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 20 Apr 2015 19:15:50 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:50 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_already_been_persisted/assigns_the_existing_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:22 GMT
+      - Mon, 08 Jun 2015 22:13:10 GMT
       Set-Cookie:
-      - BrowserId=JNG-tWgPS5qVjZfsga584g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:22 GMT
+      - BrowserId=L5W2J7TNR7OpdkKnxFQNyg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430498002630","token_type":"Bearer","instance_url":"https://<host>","signature":"Z6A0wnihwjoySQ2kx85fiWIU125nofxKEitXsJVPx+I=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:22 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801590564","token_type":"Bearer","instance_url":"https://<host>","signature":"bH/DnIivHmmpmOp3/L81bGYTPLmN1u8aBS50ySWz/0o=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:12 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:22 GMT
+      - Mon, 08 Jun 2015 22:13:10 GMT
       Set-Cookie:
-      - BrowserId=BJaSxvYtRg6BHP3eRK6dNg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:22 GMT
+      - BrowserId=5kZFHMCBSeqMcimwuQehXg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=69/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNXAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002jr5tAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:23 GMT
+      string: '{"id":"0031a000004cfNXAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:12 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002jr5tAAA"}'
+      string: '{"Friend__c":"0031a000004cfNXAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:23 GMT
+      - Mon, 08 Jun 2015 22:13:10 GMT
       Set-Cookie:
-      - BrowserId=XsRYirjeTRifK6p5q4ATsw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:23 GMT
+      - BrowserId=9eV0069YRlmPdpr3zd2fLA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:10 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=12/15000
+      - api-usage=72/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF76AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001TuP7AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:23 GMT
+      string: '{"id":"a001a000001cF76AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:12 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5tAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfNXAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:23 GMT
+      - Mon, 08 Jun 2015 22:13:11 GMT
       Set-Cookie:
-      - BrowserId=ZETXx2dvQK28gwOuQmmgRA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:23 GMT
+      - BrowserId=Hb6AXO4lSu2N5S_mwRG-_A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=13/15000
+      - api-usage=65/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA"},"Id":"0031a000002jr5tAAA","SystemModstamp":"2015-05-01T16:33:22.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:23 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfNXAAY"},"Id":"0031a000004cfNXAAY","SystemModstamp":"2015-06-08T22:13:10.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:12 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5tAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfNXAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:23 GMT
+      - Mon, 08 Jun 2015 22:13:11 GMT
       Set-Cookie:
-      - BrowserId=C8mvISe9QEiNO2UrJ583iA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:23 GMT
+      - BrowserId=8rGLvoyRTmGlCjO07_WUAQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=12/15000
+      - api-usage=76/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK"},"Id":"a001a000001TuP7AAK","SystemModstamp":"2015-05-01T16:33:23.000+0000","Name":"a001a000001TuP7","Example_Field__c":null,"Friend__c":"0031a000002jr5tAAA"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:23 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF76AAE"},"Id":"a001a000001cF76AAE","SystemModstamp":"2015-06-08T22:13:11.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF76","Example_Field__c":null,"Friend__c":"0031a000004cfNXAAY"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:12 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5tAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNXAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:23 GMT
+      - Mon, 08 Jun 2015 22:13:11 GMT
       Set-Cookie:
-      - BrowserId=hLed1XV4Ri-HpawFhu6dDA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:23 GMT
+      - BrowserId=v97LolizSoOQfo1XHX_USQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=12/15000
+      - api-usage=70/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:24 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:13 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP7AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF76AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:23 GMT
+      - Mon, 08 Jun 2015 22:13:11 GMT
       Set-Cookie:
-      - BrowserId=RN1NGcJlRqOhiwGe2jwQ6Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:23 GMT
+      - BrowserId=dI1KIVn4R4iKD2PG9xFzJg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:11 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=12/15000
+      - api-usage=66/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:24 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:13 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_associated_record_has_been_cached/uses_the_cached_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:17 GMT
+      - Mon, 08 Jun 2015 22:13:01 GMT
       Set-Cookie:
-      - BrowserId=LtTu8_z3Sp2cm5mkBgsGTw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:17 GMT
+      - BrowserId=sKqrkE6sTzS6HR0zsGbUpw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1430497997739","token_type":"Bearer","instance_url":"https://<host>","signature":"f4tQcugKKSE9kjNZgHUkr/ZXGP27pEKiZGfEskeGWgY=","access_token":"00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD"}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:18 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801581584","token_type":"Bearer","instance_url":"https://<host>","signature":"d4tqYKJNQMfCAWqkYyVInlRw7b6qGZvw8ONYXgbfAZE=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:03 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:17 GMT
+      - Mon, 08 Jun 2015 22:13:01 GMT
       Set-Cookie:
-      - BrowserId=tLtZK_c5SrWi7_EH1k-1uA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:17 GMT
+      - BrowserId=sVM1lhfRTUuv0eqcNN3RGQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=44/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNIAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000002jr5oAAA","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:18 GMT
+      string: '{"id":"0031a000004cfNIAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:03 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000002jr5oAAA"}'
+      string: '{"Friend__c":"0031a000004cfNIAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:18 GMT
+      - Mon, 08 Jun 2015 22:13:01 GMT
       Set-Cookie:
-      - BrowserId=jN5M9ObZTi-rz1DyxbAeZw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:18 GMT
+      - BrowserId=YgmNXv8nTE2MLy2xW_bfwA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=47/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6hAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001TuP2AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:18 GMT
+      string: '{"id":"a001a000001cF6hAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:03 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000002jr5oAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfNIAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:18 GMT
+      - Mon, 08 Jun 2015 22:13:02 GMT
       Set-Cookie:
-      - BrowserId=CSF-VoOoS5ChC6rHiA3_Xw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:18 GMT
+      - BrowserId=cO3LD4O8RPOv9JX0-kjYNA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=48/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA"},"Id":"0031a000002jr5oAAA","SystemModstamp":"2015-05-01T16:33:18.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:18 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfNIAAY"},"Id":"0031a000004cfNIAAY","SystemModstamp":"2015-06-08T22:13:01.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:03 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000002jr5oAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfNIAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:18 GMT
+      - Mon, 08 Jun 2015 22:13:02 GMT
       Set-Cookie:
-      - BrowserId=SWCHmZA9RwC4OyFZ5smP4g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:18 GMT
+      - BrowserId=Z6JcqrE5TASgnkg672yqeA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=45/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK"},"Id":"a001a000001TuP2AAK","SystemModstamp":"2015-05-01T16:33:18.000+0000","Name":"a001a000001TuP2","Example_Field__c":null,"Friend__c":"0031a000002jr5oAAA"}]}'
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:19 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6hAAE"},"Id":"a001a000001cF6hAAE","SystemModstamp":"2015-06-08T22:13:01.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF6h","Example_Field__c":null,"Friend__c":"0031a000004cfNIAAY"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:03 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000002jr5oAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNIAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:18 GMT
+      - Mon, 08 Jun 2015 22:13:02 GMT
       Set-Cookie:
-      - BrowserId=Wu08XNSWRJWJeDbodhrnRw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:18 GMT
+      - BrowserId=-OOcklcjSFC9OrnFTpZ7DA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=47/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:04 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001TuP2AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6hAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQDv3Hk9TRSKHVK.6TQHDjiXPpFDEH7AxoxdK.ytZcKr4gkBGokBh2ZhUcaf0_eFqhFa6YVCzmfP.bUKsz9xIJOy41iQD
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 01 May 2015 16:33:19 GMT
+      - Mon, 08 Jun 2015 22:13:02 GMT
       Set-Cookie:
-      - BrowserId=NbXpvQcjQ-eN2Vw0MceMMg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        30-Jun-2015 16:33:19 GMT
+      - BrowserId=n5dHNgOeS12RFiovV-taNQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:02 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=46/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 01 May 2015 16:33:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:04 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_build/when_the_association_is_non-building/proceeds_without_constructing_any_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:06 GMT
+      - Mon, 08 Jun 2015 22:12:17 GMT
       Set-Cookie:
-      - BrowserId=NUhYBDtmTYugORuK-TH2EA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:06 GMT
+      - BrowserId=mfWZFYFLRKes6F-kTAqq7w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431460626374","token_type":"Bearer","instance_url":"https://<host>","signature":"1Zzf/BDRxmeaZ/+eIrifZJcG35w/MfK2z4CME5hYJa8=","access_token":"00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM"}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:06 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801537311","token_type":"Bearer","instance_url":"https://<host>","signature":"y2V0cSdABtDKVkRvwsl4IPDEYiVsf+9Ak3Z9mWLlyh4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:18 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:07 GMT
+      - Mon, 08 Jun 2015 22:12:17 GMT
       Set-Cookie:
-      - BrowserId=oglbfN3hRIOSsxoVd7t9Xg;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:07 GMT
+      - BrowserId=hf3mgU77RryeHNZ0Kqe45w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMPAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000003Gm5IAAS","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:08 GMT
+      string: '{"id":"0031a000004cfMPAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:19 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000003Gm5IAAS"}'
+      string: '{"Friend__c":"0031a000004cfMPAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:08 GMT
+      - Mon, 08 Jun 2015 22:12:17 GMT
       Set-Cookie:
-      - BrowserId=rDu3h6a4QzCJ01BNom8m-A;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:08 GMT
+      - BrowserId=oabAihgVQxa_DsB1lacHuw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK8AAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4MAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZKK8AAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:09 GMT
+      string: '{"id":"a001a000001cF4MAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:19 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003Gm5IAAS%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMPAAY%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:10 GMT
+      - Mon, 08 Jun 2015 22:12:17 GMT
       Set-Cookie:
-      - BrowserId=bzTtVerbQeqmUsX-EWlJDQ;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:10 GMT
+      - BrowserId=R-CF7LBuSZWk-e2lqicynQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:17 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS"},"Id":"0031a000003Gm5IAAS","SystemModstamp":"2015-05-12T19:57:07.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:10 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMPAAY"},"Id":"0031a000004cfMPAAY","SystemModstamp":"2015-06-08T22:12:17.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003Gm5IAAS
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMPAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,22 +183,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:11 GMT
+      - Mon, 08 Jun 2015 22:12:18 GMT
       Set-Cookie:
-      - BrowserId=EscE3IkGQPup41dBUcsBQQ;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:11 GMT
+      - BrowserId=Szics5M5RwKPI86zVq1jMA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=2/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:11 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:19 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZKK8AAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4MAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -206,7 +206,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCN.EK5q2GqYClj_rprS9iFZEfWNjLjAqM_ql5mTUm5HJcVjXHY5YGQjvRhrTa_S8zNQyoc122zuBhcNpC6YS7qVpYuM
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -217,17 +217,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 12 May 2015 19:57:12 GMT
+      - Mon, 08 Jun 2015 22:12:18 GMT
       Set-Cookie:
-      - BrowserId=-PW_MFHBSiWEgiW3Lxo9GQ;Path=/;Domain=.salesforce.com;Expires=Sat,
-        11-Jul-2015 19:57:12 GMT
+      - BrowserId=W_8hKeKXT1KDW2z6JSJ1iQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=8/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Tue, 12 May 2015 19:57:12 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_a_matching_associated_record_has_been_synchronized/returns_true.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:40 GMT
+      - Mon, 08 Jun 2015 22:12:30 GMT
       Set-Cookie:
-      - BrowserId=KpR5i_fuTy2ajIP-kBJHxA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:40 GMT
+      - BrowserId=zHBKawrUQCO-J1NpwDB4Fw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715540708","token_type":"Bearer","instance_url":"https://<host>","signature":"br3UtG9nUBftzMR/OwfVXhT7UyMZMSzwe1iMucUTqME=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:41 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801550816","token_type":"Bearer","instance_url":"https://<host>","signature":"4q2jUl84gNBbC1ilLV8aRYXAOiRfh6xHAXnhtzwO+kc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:32 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:41 GMT
+      - Mon, 08 Jun 2015 22:12:30 GMT
       Set-Cookie:
-      - BrowserId=kTp0iqb3ScWx6mQBcy9I5A;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:41 GMT
+      - BrowserId=QxoHhU4ARoav3a-LayDCTQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=13/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMjAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001yZNRAA2","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:43 GMT
+      string: '{"id":"0031a000004cfMjAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:32 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001yZNRAA2"}'
+      string: '{"Friend__c":"0031a000004cfMjAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:43 GMT
+      - Mon, 08 Jun 2015 22:12:31 GMT
       Set-Cookie:
-      - BrowserId=SXz0a58GSoC1KP_RCEIrtw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:43 GMT
+      - BrowserId=QFUtSuGFQI6ZkNW7Ne60ZQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=9/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF55AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgjAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:44 GMT
+      string: '{"id":"a001a000001cF55AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNRAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMjAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:44 GMT
+      - Mon, 08 Jun 2015 22:12:31 GMT
       Set-Cookie:
-      - BrowserId=VPHQiaLWRr-iUOlWaHeRYQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:44 GMT
+      - BrowserId=FAFJr02oR4G8XgA5uUB0xQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=139/15000
+      - api-usage=10/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2"},"Id":"0031a000001yZNRAA2","SystemModstamp":"2015-04-11T01:25:41.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:45 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMjAAI"},"Id":"0031a000004cfMjAAI","SystemModstamp":"2015-06-08T22:12:31.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNRAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfMjAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:45 GMT
+      - Mon, 08 Jun 2015 22:12:31 GMT
       Set-Cookie:
-      - BrowserId=0zCCVQQwSUWrTEViLONC7A;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:45 GMT
+      - BrowserId=2Ix0noQAQGy0xLYEuzNVIQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=9/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG"},"Id":"a001a000001LXgjAAG","SystemModstamp":"2015-04-11T01:25:44.000+0000","Name":"a001a000001LXgj","Example_Field__c":null,"Friend__c":"0031a000001yZNRAA2"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:46 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF55AAE"},"Id":"a001a000001cF55AAE","SystemModstamp":"2015-06-08T22:12:31.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF55","Example_Field__c":null,"Friend__c":"0031a000004cfMjAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:33 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZNRAA2
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMjAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:46 GMT
+      - Mon, 08 Jun 2015 22:12:31 GMT
       Set-Cookie:
-      - BrowserId=2oCHkFrzR0KwQGJBfghAlQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:46 GMT
+      - BrowserId=bDbpkxxzTPSbwjsRYfLhug;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=139/15000
+      - api-usage=9/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:47 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:33 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgjAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF55AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:47 GMT
+      - Mon, 08 Jun 2015 22:12:32 GMT
       Set-Cookie:
-      - BrowserId=ct3CybiVTomsYPwhQF6T9A;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:47 GMT
+      - BrowserId=KxBVqIbYQ2SC3LMP_NCt0w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=10/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:48 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:33 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Associations_HasOne/with_an_inverse_mapping/_synced_for_/when_no_matching_associated_record_has_been_synchronized/returns_false.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:30 GMT
+      - Mon, 08 Jun 2015 22:12:39 GMT
       Set-Cookie:
-      - BrowserId=Yt3pg2-sTTCZ1bzEgnzDtQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:30 GMT
+      - BrowserId=dZXAi-UQQZyvFDJdQQ8wVg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428715530373","token_type":"Bearer","instance_url":"https://<host>","signature":"fO3Z7pIm/ub1DYu2QTcZquDZczorZ6l9epcuSgkv39U=","access_token":"00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:30 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801559092","token_type":"Bearer","instance_url":"https://<host>","signature":"K/uejVGI9/j4TuDTnG7kek5oyPD68wAVLeyHQKvpefM=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:40 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:31 GMT
+      - Mon, 08 Jun 2015 22:12:39 GMT
       Set-Cookie:
-      - BrowserId=rj8CcwJgRkyN7LZ7J2PWFw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:31 GMT
+      - BrowserId=dxHK40AkS66zo5UXZdsgpw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=22/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMyAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000001yZNMAA2","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:31 GMT
+      string: '{"id":"0031a000004cfMyAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:40 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000001yZNMAA2"}'
+      string: '{"Friend__c":"0031a000004cfMyAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:32 GMT
+      - Mon, 08 Jun 2015 22:12:39 GMT
       Set-Cookie:
-      - BrowserId=fZq5dYZIRgKWx04IrgQ9rQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:32 GMT
+      - BrowserId=_2fDAbWWSl6zduoCu-7PEg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=18/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5ZAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgBAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:33 GMT
+      string: '{"id":"a001a000001cF5ZAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:41 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000001yZNMAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMyAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:34 GMT
+      - Mon, 08 Jun 2015 22:12:39 GMT
       Set-Cookie:
-      - BrowserId=2YrKJrvMTmavduRgVGQz2g;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:34 GMT
+      - BrowserId=MRZvaAYUSi60RIBWrjH-Kw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=139/15000
+      - api-usage=21/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2"},"Id":"0031a000001yZNMAA2","SystemModstamp":"2015-04-11T01:25:31.000+0000","Email":"somebody@example.com"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:35 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMyAAI"},"Id":"0031a000004cfMyAAI","SystemModstamp":"2015-06-08T22:12:39.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:41 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000001yZNMAA2%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Friend__c%20=%20%270031a000004cfMyAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:35 GMT
+      - Mon, 08 Jun 2015 22:12:39 GMT
       Set-Cookie:
-      - BrowserId=M-7kPOfoRx22dpZCBnY2rQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:35 GMT
+      - BrowserId=HnACS_ReT02TH7sHd4P1bA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=139/15000
+      - api-usage=20/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW"},"Id":"a001a000001LXgBAAW","SystemModstamp":"2015-04-11T01:25:32.000+0000","Name":"a001a000001LXgB","Example_Field__c":null,"Friend__c":"0031a000001yZNMAA2"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:36 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5ZAAU"},"Id":"a001a000001cF5ZAAU","SystemModstamp":"2015-06-08T22:12:39.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF5Z","Example_Field__c":null,"Friend__c":"0031a000004cfMyAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:41 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000001yZNMAA2
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMyAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:37 GMT
+      - Mon, 08 Jun 2015 22:12:40 GMT
       Set-Cookie:
-      - BrowserId=R28d6c0nQdyO9vziai3iVw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:37 GMT
+      - BrowserId=S_9DLI3mTKK0lcqQ825nwg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=23/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:37 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:41 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgBAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5ZAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKzh13pKuR2SlS.Cq04BnD.sliu.0jLuP2qUQvVfZBc5RaiRknImPjcZu5w_dvIzyN831OnqnR.o9XKdgX14n3l6dNnj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,17 +255,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 01:25:38 GMT
+      - Mon, 08 Jun 2015 22:12:40 GMT
       Set-Cookie:
-      - BrowserId=5DnZjUYsRwCLgm7PTGRjrA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 01:25:38 GMT
+      - BrowserId=VJqrN-9xSZ-LYc-q22Hv8g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=138/15000
+      - api-usage=23/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 01:25:38 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:42 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
+++ b/test/cassettes/Restforce_DB_Associator/_run/given_a_BelongsTo_association/given_another_record_for_association/when_the_database_association_is_out_of_date/updates_the_associated_record_in_the_database.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:35 GMT
+      - Mon, 08 Jun 2015 22:12:27 GMT
       Set-Cookie:
-      - BrowserId=1j7CSGxXSGmABTSLNdV-OA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:35 GMT
+      - BrowserId=PljA7O7qSS-LNzRDqzbejA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652895803","token_type":"Bearer","instance_url":"https://<host>","signature":"yr5PJJM+uMppHWQ3IDul6FOK9ofJZTvM750pL/4ajSc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:35 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801547685","token_type":"Bearer","instance_url":"https://<host>","signature":"UMbVwt9e5I7tQEF5uWbiI1DzVkUeJJoII7D/TGaMJwU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:29 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:36 GMT
+      - Mon, 08 Jun 2015 22:12:27 GMT
       Set-Cookie:
-      - BrowserId=QQ1PZaNPR0yuaV1iXOTIZA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:36 GMT
+      - BrowserId=o_ZVVWhdRMWciaBCY54DhQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=718/15000
+      - api-usage=11/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISkAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMZAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000003QISkAAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:36 GMT
+      string: '{"id":"0031a000004cfMZAAY","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:29 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000003QISkAAO"}'
+      string: '{"Friend__c":"0031a000004cfMZAAY"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,25 +105,25 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:37 GMT
+      - Mon, 08 Jun 2015 22:12:28 GMT
       Set-Cookie:
-      - BrowserId=w26m8U-hSHqxflHspZx7Qg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:37 GMT
+      - BrowserId=aVWcZBKoRySWvnKapVMdEw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=719/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoEUAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:37 GMT
+      string: '{"id":"a001a000001cF50AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:29 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/Contact
@@ -136,7 +136,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -147,28 +147,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:38 GMT
+      - Mon, 08 Jun 2015 22:12:28 GMT
       Set-Cookie:
-      - BrowserId=a4FGlAw4RYGPvvpUZT5p0w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:38 GMT
+      - BrowserId=5iN3KSxhTg2BtetjFZi4wA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=722/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO"
+      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfMeAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0031a000003QISpAAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:38 GMT
+      string: '{"id":"0031a000004cfMeAAI","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:29 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF50AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -187,23 +187,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:40 GMT
+      - Mon, 08 Jun 2015 22:12:28 GMT
       Set-Cookie:
-      - BrowserId=Pm2BjS4wQpuRUDQVSFdgTA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:40 GMT
+      - BrowserId=FysEyIfaRtaGsXJNHsoL-w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=723/15000
+      - api-usage=11/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:37.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISkAAO"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:40 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE"},"Id":"a001a000001cF50AAE","SystemModstamp":"2015-06-08T22:12:28.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF50","Example_Field__c":null,"Friend__c":"0031a000004cfMZAAY"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:30 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -214,7 +214,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -225,14 +225,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:41 GMT
+      - Mon, 08 Jun 2015 22:12:28 GMT
       Set-Cookie:
-      - BrowserId=vgOB3GmNS-2Qwk-eDaYASQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:41 GMT
+      - BrowserId=ZtQPES6ASpqSPECNoXHrlA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=723/15000
+      - api-usage=10/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -245,7 +245,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -254,22 +254,22 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:41 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:30 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000003QISpAAO"}'
+      string: '{"Friend__c":"0031a000004cfMeAAI"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -280,22 +280,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:41 GMT
+      - Mon, 08 Jun 2015 22:12:28 GMT
       Set-Cookie:
-      - BrowserId=ZtQi1P1wTFOO-BS2sQHmCA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:41 GMT
+      - BrowserId=tkZRlDNARR6CkmpKcjzJWw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:28 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=730/15000
+      - api-usage=11/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:42 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:30 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -303,7 +303,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -314,26 +314,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:43 GMT
+      - Mon, 08 Jun 2015 22:12:29 GMT
       Set-Cookie:
-      - BrowserId=rYYX9amqQT6kuQMDBWMwOw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:43 GMT
+      - BrowserId=AIIDMeBcT4yBjecjix89lA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=729/15000
+      - api-usage=10/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:43 GMT
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null,"Friend__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE"},"Id":"a001a000001cF50AAE","SystemModstamp":"2015-06-08T22:12:29.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF50","Example_Field__c":null,"Friend__c":"0031a000004cfMeAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:30 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000003QISpAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Email%20from%20Contact%20where%20Id%20=%20%270031a000004cfMeAAI%27
     body:
       encoding: US-ASCII
       string: ''
@@ -341,7 +341,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -352,26 +352,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:44 GMT
+      - Mon, 08 Jun 2015 22:12:29 GMT
       Set-Cookie:
-      - BrowserId=yKlOS9VtQ7aGgNSknycrxQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:44 GMT
+      - BrowserId=XWJQla25SoyR-sGefQgRuQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=730/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO"},"Id":"0031a000003QISpAAO","SystemModstamp":"2015-05-15T01:21:38.000+0000","Email":"somebody+else@example.com"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:44 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Contact","url":"/services/data/<api_version>/sobjects/Contact/0031a000004cfMeAAI"},"Id":"0031a000004cfMeAAI","SystemModstamp":"2015-06-08T22:12:28.000+0000","LastModifiedById":"0051a000000UGT8AAO","Email":"somebody+else@example.com"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:30 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoEUAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF50AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -379,7 +379,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -390,26 +390,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:45 GMT
+      - Mon, 08 Jun 2015 22:12:29 GMT
       Set-Cookie:
-      - BrowserId=pbASLlFmRhSy-BauVuOpEg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:45 GMT
+      - BrowserId=tEB2iCzOT-Kg1X4QSI-a-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=729/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0"},"Id":"a001a000001ZoEUAA0","SystemModstamp":"2015-05-15T01:21:41.000+0000","Name":"a001a000001ZoEU","Example_Field__c":null,"Friend__c":"0031a000003QISpAAO"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:45 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE"},"Id":"a001a000001cF50AAE","SystemModstamp":"2015-06-08T22:12:29.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF50","Example_Field__c":null,"Friend__c":"0031a000004cfMeAAI"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:31 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISkAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMZAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -417,7 +417,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -428,22 +428,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:46 GMT
+      - Mon, 08 Jun 2015 22:12:29 GMT
       Set-Cookie:
-      - BrowserId=wVZfZ1Y5RHqBG8xsN5EIqA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:46 GMT
+      - BrowserId=TyTkNiVzQ_GIdFpd0gPxaQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:29 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=727/15000
+      - api-usage=10/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:46 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:31 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEUAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF50AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -451,7 +451,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -462,22 +462,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:47 GMT
+      - Mon, 08 Jun 2015 22:12:30 GMT
       Set-Cookie:
-      - BrowserId=j_B7gKC7QiCb6OFfFp1_JQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:47 GMT
+      - BrowserId=nQ52EC7uRIKjypjlgvgpFA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=733/15000
+      - api-usage=11/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:47 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:31 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000003QISpAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfMeAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -485,7 +485,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -496,17 +496,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:48 GMT
+      - Mon, 08 Jun 2015 22:12:30 GMT
       Set-Cookie:
-      - BrowserId=Hq_fjWhsTy24DcQPF8He9g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:48 GMT
+      - BrowserId=Ssjbd3_ORl6B2tL52x1PPg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=729/15000
+      - api-usage=9/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:48 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:32 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_mapping_has_no_conditions/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_mapping_has_no_conditions/does_not_drop_the_synchronized_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:57 GMT
+      - Mon, 08 Jun 2015 22:12:34 GMT
       Set-Cookie:
-      - BrowserId=Flpm78MlSe67R7xkifj2Yw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:57 GMT
+      - BrowserId=iu3q7G_hRfGVXbUXSJvgmg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652737381","token_type":"Bearer","instance_url":"https://<host>","signature":"eDi+FfWSG5svT9zP9racSdUlz4GQ3ZX37gNEFN5JYyk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:57 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801554173","token_type":"Bearer","instance_url":"https://<host>","signature":"XPgo8B+xisNxNpNt8j1/nadrjh3j9fX7CHqyNRWIQps=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:35 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,28 +64,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:58 GMT
+      - Mon, 08 Jun 2015 22:12:34 GMT
       Set-Cookie:
-      - BrowserId=IrKaoFW2SHGjeIBDQTZqvA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:58 GMT
+      - BrowserId=Das_Y3JUSa2OBNJ0k5_-8w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=624/15000
+      - api-usage=13/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCiAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5FAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoCiAAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:58 GMT
+      string: '{"id":"a001a000001cF5FAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:35 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCiAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5FAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -104,17 +104,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:59 GMT
+      - Mon, 08 Jun 2015 22:12:34 GMT
       Set-Cookie:
-      - BrowserId=RgPz1kLLRwu-QDIxksKAYQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:59 GMT
+      - BrowserId=WAx2TkLxTXKE8l5J-Ofaeg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=623/15000
+      - api-usage=11/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:59 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/but_meets_conditions_for_a_parallel_mapping/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/but_meets_conditions_for_a_parallel_mapping/does_not_drop_the_synchronized_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:06 GMT
+      - Mon, 08 Jun 2015 22:12:37 GMT
       Set-Cookie:
-      - BrowserId=_VzSmIBGQDSnHzsFd92wSw;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:06 GMT
+      - BrowserId=H-Ao6JHQQN6MkLDwjcTfmA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1432078446774","token_type":"Bearer","instance_url":"https://<host>","signature":"48fp5x1JIofOq/1TfWCcVBdJ9avsYcASae3gNE0nvY8=","access_token":"00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801557688","token_type":"Bearer","instance_url":"https://<host>","signature":"jR7J+a16rGTcPtjAswSguhNaDWTb4xe3hvgSUNbEPtw=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:07 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:39 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,28 +64,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:07 GMT
+      - Mon, 08 Jun 2015 22:12:37 GMT
       Set-Cookie:
-      - BrowserId=DkVjne2rRouMphjk0Sm1kQ;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:07 GMT
+      - BrowserId=zUn0iRCJTIK0lwN9Uv2fmQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=12/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aBJtAAM"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5UAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001aBJtAAM","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF5UAAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:08 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:39 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -104,28 +104,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:08 GMT
+      - Mon, 08 Jun 2015 22:12:38 GMT
       Set-Cookie:
-      - BrowserId=mEliqh0IQs-g-XTscrAhQg;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:08 GMT
+      - BrowserId=nmVPyn5tRL24WuQPP8_Czw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=13/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aBJtAAM"},"Id":"a001a000001aBJtAAM","SystemModstamp":"2015-05-19T23:34:07.000+0000","Name":"Are
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5UAAU"},"Id":"a001a000001cF5UAAU","SystemModstamp":"2015-06-08T22:12:37.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:09 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:39 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -144,26 +144,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:09 GMT
+      - Mon, 08 Jun 2015 22:12:38 GMT
       Set-Cookie:
-      - BrowserId=2pGvHX3ZRECV7rJT4dC3fA;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:09 GMT
+      - BrowserId=WVVxZXLnQhusLHAO-uUtUg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=18/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","Name":"SAMPLE","Example_Field__c":null}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null}]}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:10 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:39 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -171,7 +171,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -182,28 +182,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:10 GMT
+      - Mon, 08 Jun 2015 22:12:38 GMT
       Set-Cookie:
-      - BrowserId=uprM5FLJQDetuw1q9hKvwg;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:10 GMT
+      - BrowserId=uhQTItfVTVy3xhNf31CV5g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=18/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aBJtAAM"},"Id":"a001a000001aBJtAAM","SystemModstamp":"2015-05-19T23:34:07.000+0000","Name":"Are
-        you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
-        and Thyme."}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5UAAU"},"Id":"a001a000001cF5UAAU","SystemModstamp":"2015-06-08T22:12:37.000+0000","LastModifiedById":"0051a000000UGT8AAO"}]}'
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:10 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:40 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aBJtAAM
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5UAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -211,7 +209,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIsaMmpVY0MkRAqWjHsN6PVfiwFjj_vqrELuCJU8J.FPDa6glYHoGFCZl6CQZWwdOfR89R0VSsJBD9SUvJv1jfsIJGAB
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -222,10 +220,10 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Tue, 19 May 2015 23:34:11 GMT
+      - Mon, 08 Jun 2015 22:12:38 GMT
       Set-Cookie:
-      - BrowserId=Zruo3pklQ_ub4MdPrZp_5Q;Path=/;Domain=.salesforce.com;Expires=Sat,
-        18-Jul-2015 23:34:11 GMT
+      - BrowserId=dZWfNi2_Qd-Ri3vyifVAsQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:38 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -234,5 +232,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Tue, 19 May 2015 23:34:12 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:40 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/drops_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_does_not_meet_the_mapping_conditions/drops_the_synchronized_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:30 GMT
+      - Mon, 08 Jun 2015 22:12:52 GMT
       Set-Cookie:
-      - BrowserId=E_1YTVCUQsaftF55tGMiqw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:30 GMT
+      - BrowserId=GrokNMX-RCWCZ2FMxcpz3w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652890698","token_type":"Bearer","instance_url":"https://<host>","signature":"0evU70RDGPagRqFniwNzBo1tfyh5vTuYv+0/JBWjpuk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:30 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801572363","token_type":"Bearer","instance_url":"https://<host>","signature":"d4h0SNUB5fyCgZlXR+Tk4+iym/m0huurkZxaP3ldZW4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:53 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,28 +64,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:31 GMT
+      - Mon, 08 Jun 2015 22:12:52 GMT
       Set-Cookie:
-      - BrowserId=fTB3kvgnRAmnaxlskVAN2Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:31 GMT
+      - BrowserId=7Kz9-m8vSkKUHuQsR-Yxaw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=716/15000
+      - api-usage=30/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF68AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoEPAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:31 GMT
+      string: '{"id":"a001a000001cF68AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:54 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -104,28 +104,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:32 GMT
+      - Mon, 08 Jun 2015 22:12:52 GMT
       Set-Cookie:
-      - BrowserId=bQlg2D4rSwKYlP7RBCSGTg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:32 GMT
+      - BrowserId=nL_mqaOeR9SMe_BG-HjbWA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=718/15000
+      - api-usage=34/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0"},"Id":"a001a000001ZoEPAA0","SystemModstamp":"2015-05-15T01:21:31.000+0000","Name":"Are
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF68AAE"},"Id":"a001a000001cF68AAE","SystemModstamp":"2015-06-08T22:12:52.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:32 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:54 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20!=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -144,26 +144,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:33 GMT
+      - Mon, 08 Jun 2015 22:12:52 GMT
       Set-Cookie:
-      - BrowserId=xE1B9MaBS1egHKfnLCLJ3w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:33 GMT
+      - BrowserId=RVFXRrWCRwmOTjiGbpYadA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=717/15000
+      - api-usage=32/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:33 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEPAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF68AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -171,7 +171,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -182,17 +182,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:21:34 GMT
+      - Mon, 08 Jun 2015 22:12:53 GMT
       Set-Cookie:
-      - BrowserId=FweFSQPHTYaX13IOz-IItg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:21:34 GMT
+      - BrowserId=bJaKjXfbTw6CaVbWzOvvtA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=715/15000
+      - api-usage=35/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:21:34 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:54 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_has_been_deleted_in_Salesforce/drops_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_has_been_deleted_in_Salesforce/drops_the_synchronized_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 20 May 2015 22:04:31 GMT
+      - Mon, 08 Jun 2015 22:12:54 GMT
       Set-Cookie:
-      - BrowserId=bSV2iUXwSSOWJFCXI7O_RA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        19-Jul-2015 22:04:31 GMT
+      - BrowserId=QXKr2CxzTVuMZKp76C0-zQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1432159471623","token_type":"Bearer","instance_url":"https://<host>","signature":"vlqOCnMqVU2ShrK2bLIsZTK24INW4Z4LpDdILzgxrFs=","access_token":"00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801574347","token_type":"Bearer","instance_url":"https://<host>","signature":"Cir1RVdkVwKnTaUxBuuAUT7/ZkCzJvV+tSO/0ZvOKhc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Wed, 20 May 2015 22:04:31 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:55 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,28 +64,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 20 May 2015 22:04:31 GMT
+      - Mon, 08 Jun 2015 22:12:54 GMT
       Set-Cookie:
-      - BrowserId=iTltKbJMRMS2WMP0BxPVvg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        19-Jul-2015 22:04:31 GMT
+      - BrowserId=ZSu3nPFVSxKU30Su9AVaoA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/15000
+      - api-usage=35/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aHLuAAM"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6DAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001aHLuAAM","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF6DAAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Wed, 20 May 2015 22:04:31 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:56 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001aHLuAAM
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6DAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQPRrI9oLwB7KrYUUG5M8JsqJ4YAQepwPNs0vuNDy1phuqeS5ZoO0WecEoXrGBflaKK9LegZ0cFfz2FZwe9v4MZFSUlc6
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -104,17 +104,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 20 May 2015 22:04:32 GMT
+      - Mon, 08 Jun 2015 22:12:54 GMT
       Set-Cookie:
-      - BrowserId=6WNubRIVSxG4Hy8WSNOcaw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        19-Jul-2015 22:04:32 GMT
+      - BrowserId=5gJUZduHRJ6hcOYwZ_SapA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/15000
+      - api-usage=32/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 20 May 2015 22:04:32 GMT
+  recorded_at: Mon, 08 Jun 2015 22:12:56 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
+++ b/test/cassettes/Restforce_DB_Cleaner/_run/given_a_synchronized_Salesforce_record/when_the_record_meets_the_mapping_conditions/does_not_drop_the_synchronized_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:34:07 GMT
+      - Mon, 08 Jun 2015 22:13:14 GMT
       Set-Cookie:
-      - BrowserId=PlvBJsmsQl2Ua2NNWOb3lg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:34:07 GMT
+      - BrowserId=agqagTLISdCA00ihcd9U_g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431653647956","token_type":"Bearer","instance_url":"https://<host>","signature":"0Y5hzj5yAfpvGVh+sdgK56/XvRhuAg1oyXBywP0nOwE=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:34:07 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801594169","token_type":"Bearer","instance_url":"https://<host>","signature":"L75sPoHvnw5b46r3AFFUDHEF+ljiUKXh9tOxEY57N5g=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:15 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -53,7 +53,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -64,28 +64,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:34:08 GMT
+      - Mon, 08 Jun 2015 22:13:14 GMT
       Set-Cookie:
-      - BrowserId=16qh2C_0Rh28tGWSD55c4w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:34:08 GMT
+      - BrowserId=Yq-kfO-gQACQTQkS6yF2hQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=806/15000
+      - api-usage=98/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7GAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoEoAAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:34:08 GMT
+      string: '{"id":"a001a000001cF7GAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:15 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -93,7 +93,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -104,28 +104,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:34:10 GMT
+      - Mon, 08 Jun 2015 22:13:14 GMT
       Set-Cookie:
-      - BrowserId=Fpx4klHITVyqczp5DuSzqA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:34:10 GMT
+      - BrowserId=oxkrJRWNQgiCqBgzOvpGVQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=806/15000
+      - api-usage=102/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7GAAU"},"Id":"a001a000001cF7GAAU","SystemModstamp":"2015-06-08T22:13:14.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:34:10 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:16 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Name%20=%20%27Are%20you%20going%20to%20Scarborough%20Fair?%27
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -144,28 +144,28 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:34:11 GMT
+      - Mon, 08 Jun 2015 22:13:14 GMT
       Set-Cookie:
-      - BrowserId=qeq0i8FKR6CM0Sb9B7nswg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:34:11 GMT
+      - BrowserId=eKAll_F8TNCC_8PAEBIM0w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=806/15000
+      - api-usage=97/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK"},"Id":"a001a000001ZoEoAAK","SystemModstamp":"2015-05-15T01:34:08.000+0000","Name":"Are
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7GAAU"},"Id":"a001a000001cF7GAAU","SystemModstamp":"2015-06-08T22:13:14.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Are
         you going to Scarborough Fair?","Example_Field__c":"Parsley, Sage, Rosemary,
         and Thyme."}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:34:11 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:16 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoEoAAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7GAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -173,7 +173,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -184,17 +184,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:34:12 GMT
+      - Mon, 08 Jun 2015 22:13:14 GMT
       Set-Cookie:
-      - BrowserId=WZLkP1ihSbeq_nlkOpDByQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:34:12 GMT
+      - BrowserId=E7zKHLIFSN2EsYeOlh7nxg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=806/15000
+      - api-usage=98/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:34:12 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:16 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:04 GMT
+      - Mon, 08 Jun 2015 22:12:26 GMT
       Set-Cookie:
-      - BrowserId=1-W-oxIGS2WOOLOo6wzW2A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:04 GMT
+      - BrowserId=IUZDct2tRqSbtEnKBAjLkA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313624267","token_type":"Bearer","instance_url":"https://<host>","signature":"ABLounL9O5kFDJ9y/g/l4dLcm/HQOU8UIF9L3wpVmng=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:04 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801546572","token_type":"Bearer","instance_url":"https://<host>","signature":"eWPqcCY6D2iKBFJv8pRBafWGp81i1uiYtMQhH3ams1A=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:05 GMT
+      - Mon, 08 Jun 2015 22:12:26 GMT
       Set-Cookie:
-      - BrowserId=dE26sxE8Rl-Rumx82ekC0Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:05 GMT
+      - BrowserId=2hj5KwxMTnyS57eKQkeL-A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=9/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LGf9AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:05 GMT
+      string: '{"id":"a001a000001cF4vAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGf9AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4vAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:06 GMT
+      - Mon, 08 Jun 2015 22:12:26 GMT
       Set-Cookie:
-      - BrowserId=t7abvz2zRKWKmlx5GTtwMw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:06 GMT
+      - BrowserId=_JZ2ryP4TlOZ6qkKrYZrkw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"},"Id":"a001a000001cF4vAAE","SystemModstamp":"2015-06-08T22:12:26.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:06 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:06Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:07 GMT
+      - Mon, 08 Jun 2015 22:12:27 GMT
       Set-Cookie:
-      - BrowserId=RphmGcW7T66OthKLT_v52w;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:07 GMT
+      - BrowserId=4BMkj87_RF2aLa2fDpaD5Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG"},"Id":"a001a000001LGf9AAG","SystemModstamp":"2015-04-06T09:47:05.000+0000","Name":"Custom
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"},"Id":"a001a000001cF4vAAE","SystemModstamp":"2015-06-08T22:12:26.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:07 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGf9AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +181,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:08 GMT
+      - Mon, 08 Jun 2015 22:12:27 GMT
       Set-Cookie:
-      - BrowserId=oPwfk9OFQpKhvzl0QDNZ1Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:08 GMT
+      - BrowserId=cRMxZ9gSSN2YVrMFxyeCEw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:27 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=9/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:09 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:10 GMT
+      - Mon, 08 Jun 2015 22:12:45 GMT
       Set-Cookie:
-      - BrowserId=GYwnKzDZSXW2pS0fi86B-Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:10 GMT
+      - BrowserId=WKJBDf2wS9yoOjMIgd5GVg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313630193","token_type":"Bearer","instance_url":"https://<host>","signature":"ApVLPX1o4/XFwiO/5YCw9BePXEF1eqtQcn5fdHsn9cI=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:10 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801565981","token_type":"Bearer","instance_url":"https://<host>","signature":"tcufiqR1IVzUzMvBFfvPgcLtI2Xh/s0F+UZJ22yVee0=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:11 GMT
+      - Mon, 08 Jun 2015 22:12:46 GMT
       Set-Cookie:
-      - BrowserId=f3N4KWB3TCCtg_ZNr1YUOA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:11 GMT
+      - BrowserId=bxs8gUr1T-2ytKX8wxVUrQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=29/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LGfEAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:11 GMT
+      string: '{"id":"a001a000001cF5tAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGfEAAW%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5tAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:12 GMT
+      - Mon, 08 Jun 2015 22:12:46 GMT
       Set-Cookie:
-      - BrowserId=O5AXigkwScCVCQ_O3JaAiQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:12 GMT
+      - BrowserId=vQbLE1ABSQuNHocFh6nwqg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=27/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"},"Id":"a001a000001cF5tAAE","SystemModstamp":"2015-06-08T22:12:46.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:12 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:12Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:13 GMT
+      - Mon, 08 Jun 2015 22:12:46 GMT
       Set-Cookie:
-      - BrowserId=g-5Hn4m0RYqtYjdU8FhUfw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:13 GMT
+      - BrowserId=q3u3iCrgSqaR3zeQeQ284Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=15/15000
+      - api-usage=27/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW"},"Id":"a001a000001LGfEAAW","SystemModstamp":"2015-04-06T09:47:11.000+0000","Name":"Custom
+      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"},"Id":"a001a000001cF5tAAE","SystemModstamp":"2015-06-08T22:12:46.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:13 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGfEAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +181,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:14 GMT
+      - Mon, 08 Jun 2015 22:12:46 GMT
       Set-Cookie:
-      - BrowserId=NB2Kj_8CSFy1w02HjcWRfQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:14 GMT
+      - BrowserId=k05v9q6lRV6J82d_MPkehw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=16/15000
+      - api-usage=24/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:14 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:15 GMT
+      - Mon, 08 Jun 2015 22:12:26 GMT
       Set-Cookie:
-      - BrowserId=iKvYr10tSN21kZP4Ayl0oQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:15 GMT
+      - BrowserId=FXMQW0CNQ-CxdRdIg0pZyw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,12 +37,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428313635415","token_type":"Bearer","instance_url":"https://<host>","signature":"qgEz8rnSJoiUzNODq0gJyMJXLTeQ+pjzTyA1BwJ1Nq8=","access_token":"00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_"}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:15 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801546149","token_type":"Bearer","instance_url":"https://<host>","signature":"OpfQrQSzS7CXjr7GajZRRWSr46FQiYAZKJajUpjOWBU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20SystemModstamp%20%3C%202015-04-06T09:47:14Z
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +50,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEcyaEa1EiezSuMSEJm73cIL8I5CDJ_vnqlgzm7mAXRhbGBSo3xF6_EdmNqSa42nDRyl2szOaP4ybHrIHxo.G4YonU_
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -61,21 +61,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 09:47:16 GMT
+      - Mon, 08 Jun 2015 22:12:26 GMT
       Set-Cookie:
-      - BrowserId=-Oj4BnncTOaI79jHDt5lUg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 09:47:16 GMT
+      - BrowserId=dM5SIvpNQp6Hdo3R5FfeWw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=10/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 09:47:16 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_a_Passive_strategy/does_not_create_a_database_record.yml
+++ b/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_Salesforce_record/for_a_Passive_strategy/does_not_create_a_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 08 Apr 2015 20:53:27 GMT
+      - Mon, 08 Jun 2015 22:12:23 GMT
       Set-Cookie:
-      - BrowserId=JiecschETr-qIUUCvn1_3A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 20:53:27 GMT
+      - BrowserId=Jf8JfcVlQXGIkgPOVSAPnQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428526407882","token_type":"Bearer","instance_url":"https://<host>","signature":"b8JiQgpUdbWK4ZF5QL688+niNH2pYF3BCX6iynboWVI=","access_token":"00D1a000000H3O9!AQ4AQNyTp4z9oP2.J3Cn7NYTEhEEQDKps55QWmUhH0v3eAk6P1DoAUmVHKUnCITNabWF1iOMeT46TMEQTZdyM7pnT5JNIYfj"}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 20:53:26 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801543720","token_type":"Bearer","instance_url":"https://<host>","signature":"KtvtRrE3bQFvZ42nlJ6pMlUXwFSOL5syQM2m3xAsHPQ=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:25 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNyTp4z9oP2.J3Cn7NYTEhEEQDKps55QWmUhH0v3eAk6P1DoAUmVHKUnCITNabWF1iOMeT46TMEQTZdyM7pnT5JNIYfj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 08 Apr 2015 20:53:28 GMT
+      - Mon, 08 Jun 2015 22:12:23 GMT
       Set-Cookie:
-      - BrowserId=87n8PrMESjOEdEKnA7TnHQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 20:53:28 GMT
+      - BrowserId=RLkQfLdsQR-VgS6PH4xR4w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=16/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKUAA4"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4lAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LNKUAA4","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 20:53:27 GMT
+      string: '{"id":"a001a000001cF4lAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:25 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LNKUAA4
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4lAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQNyTp4z9oP2.J3Cn7NYTEhEEQDKps55QWmUhH0v3eAk6P1DoAUmVHKUnCITNabWF1iOMeT46TMEQTZdyM7pnT5JNIYfj
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,17 +103,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 08 Apr 2015 20:53:28 GMT
+      - Mon, 08 Jun 2015 22:12:24 GMT
       Set-Cookie:
-      - BrowserId=fsY3im3GQPqY5-Qq43gYqQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 20:53:28 GMT
+      - BrowserId=utArcJ7OSi2u75uX6EKWvg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:24 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=14/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 20:53:27 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:25 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_database_record/for_an_Always_strategy/populates_Salesforce_with_the_new_record.yml
+++ b/test/cassettes/Restforce_DB_Initializer/_run/given_an_existing_database_record/for_an_Always_strategy/populates_Salesforce_with_the_new_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:40 GMT
+      - Mon, 08 Jun 2015 22:13:21 GMT
       Set-Cookie:
-      - BrowserId=vH7gxJCRS7Ggf433XwCF5w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:40 GMT
+      - BrowserId=X_lZ2UPDSpeo9gWm8kD1mw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,12 +37,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431654460979","token_type":"Bearer","instance_url":"https://<host>","signature":"/pcrxVbljG/4hKqmruGYfY8UiObCMPYIx3CgyVTV2Wk=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:40 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801601678","token_type":"Bearer","instance_url":"https://<host>","signature":"pCaP3SbgusCMAnEdVlM3F9fkaMe5LmtrNhBEOqAle+A=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:23 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +50,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -61,23 +61,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:42 GMT
+      - Mon, 08 Jun 2015 22:13:21 GMT
       Set-Cookie:
-      - BrowserId=bEPCvNYsRe-afREDcX96Vg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:42 GMT
+      - BrowserId=19TFakWMQFWE4Hk7h4zMmQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=810/15000
+      - api-usage=109/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:42 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:23 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -88,7 +88,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -99,14 +99,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:43 GMT
+      - Mon, 08 Jun 2015 22:13:22 GMT
       Set-Cookie:
-      - BrowserId=Hx2Tp-0gSZG-FZCNHJvkfQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:43 GMT
+      - BrowserId=rh_fzB9BQPWtnSKyheqDEA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=811/15000
+      - api-usage=102/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -119,7 +119,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -128,9 +128,9 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:43 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:23 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -143,7 +143,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -154,28 +154,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:44 GMT
+      - Mon, 08 Jun 2015 22:13:22 GMT
       Set-Cookie:
-      - BrowserId=3H3DbHB-QeW85UpsMPHBXA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:44 GMT
+      - BrowserId=Gj7Hz1IoQRSGl1N5Ac2SMw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=812/15000
+      - api-usage=98/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7fAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoF8AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:44 GMT
+      string: '{"id":"a001a000001cF7fAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:23 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7fAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -183,7 +183,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -194,27 +194,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:45 GMT
+      - Mon, 08 Jun 2015 22:13:22 GMT
       Set-Cookie:
-      - BrowserId=ij4aL1ZsQ-2Y7FXgl3K5NA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:45 GMT
+      - BrowserId=WYNqGU1RREa7eAYGEJMtzw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=812/15000
+      - api-usage=99/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7fAAE"},"Id":"a001a000001cF7fAAE","SystemModstamp":"2015-06-08T22:13:22.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:45 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:24 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF8AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7fAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -222,7 +222,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -233,27 +233,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:46 GMT
+      - Mon, 08 Jun 2015 22:13:22 GMT
       Set-Cookie:
-      - BrowserId=C2TsqQrYRDSY5BkuVTkFNA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:46 GMT
+      - BrowserId=sj5L_u3dTXWmAVEUVMSCKA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=811/15000
+      - api-usage=106/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK"},"Id":"a001a000001ZoF8AAK","SystemModstamp":"2015-05-15T01:47:44.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7fAAE"},"Id":"a001a000001cF7fAAE","SystemModstamp":"2015-06-08T22:13:22.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:46 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:24 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF8AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7fAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -261,7 +261,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -272,17 +272,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:47 GMT
+      - Mon, 08 Jun 2015 22:13:22 GMT
       Set-Cookie:
-      - BrowserId=aB4FZuCgS1yb2aGw0Zc2YA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:47 GMT
+      - BrowserId=jMXklkWqRY2qJXIZ9hwyfw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=812/15000
+      - api-usage=104/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:47 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:24 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_a_matching_database_record_exists/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_a_matching_database_record_exists/returns_true.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:25 GMT
+      - Mon, 08 Jun 2015 22:13:00 GMT
       Set-Cookie:
-      - BrowserId=fERSgZ4JTeuiJriZGh5z5g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:25 GMT
+      - BrowserId=-GC1J46JT-eG9uM1r_xjYA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428332485560","token_type":"Bearer","instance_url":"https://<host>","signature":"GBS/8ndYpWxyywchO4vevnh1DcQqCs1JQ+G8a/Ju8T4=","access_token":"00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil"}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:25 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801580648","token_type":"Bearer","instance_url":"https://<host>","signature":"nVHEco0bNlkpnj5+GTmV9H1gaUWrSeTvAztBg2GQhRk=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:02 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:27 GMT
+      - Mon, 08 Jun 2015 22:13:00 GMT
       Set-Cookie:
-      - BrowserId=35nO5t0KR8ukyZaToZMtpw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:27 GMT
+      - BrowserId=2bZXXsLjRVOgIZ_ytnMCNw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=25/15000
+      - api-usage=48/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6cAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LGpnAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:27 GMT
+      string: '{"id":"a001a000001cF6cAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:02 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpnAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6cAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:28 GMT
+      - Mon, 08 Jun 2015 22:13:01 GMT
       Set-Cookie:
-      - BrowserId=oAxfzYGTTZSrw3A6NzKQ9g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:28 GMT
+      - BrowserId=-7-fSch3SLWeoFJcz8RJ4w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=46/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG"},"Id":"a001a000001LGpnAAG","SystemModstamp":"2015-04-06T15:01:27.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6cAAE"},"Id":"a001a000001cF6cAAE","SystemModstamp":"2015-06-08T22:13:00.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:28 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:02 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpnAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6cAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:31 GMT
+      - Mon, 08 Jun 2015 22:13:01 GMT
       Set-Cookie:
-      - BrowserId=x--P6F6eRS2VDmm5GzlWnw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:31 GMT
+      - BrowserId=5eMYZ5qzTMy_raR4IMLw9A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=42/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:31 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:02 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_no_matching_database_record_exists/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_synced_/when_no_matching_database_record_exists/returns_false.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:20 GMT
+      - Mon, 08 Jun 2015 22:12:59 GMT
       Set-Cookie:
-      - BrowserId=9UkDltOYSSu1vP54zLx4QQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:20 GMT
+      - BrowserId=YcEwcmv6TqOZjcBKGxJaxw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428332480120","token_type":"Bearer","instance_url":"https://<host>","signature":"EUwqb7x31VJ+yJ0lgsC7JwgnXdSItzgBAL8Kos1gDnQ=","access_token":"00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil"}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:20 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801579759","token_type":"Bearer","instance_url":"https://<host>","signature":"wmD98NNT4Fw0/HJ76xc65kukRKFk3VoK6qwToCECTXU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:01 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:21 GMT
+      - Mon, 08 Jun 2015 22:12:59 GMT
       Set-Cookie:
-      - BrowserId=o6ko1pC1SeiZoZdFI8DKQw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:21 GMT
+      - BrowserId=w-2DEtEQSHyfoSAljNDZwA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=49/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6XAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LGpiAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:21 GMT
+      string: '{"id":"a001a000001cF6XAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:01 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LGpiAAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6XAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:23 GMT
+      - Mon, 08 Jun 2015 22:13:00 GMT
       Set-Cookie:
-      - BrowserId=_eUCOgR0Q0qTFj6plVjkFA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:23 GMT
+      - BrowserId=gd2Wq1t4R5GnvWBUFAc73w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=50/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG"},"Id":"a001a000001LGpiAAG","SystemModstamp":"2015-04-06T15:01:21.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6XAAU"},"Id":"a001a000001cF6XAAU","SystemModstamp":"2015-06-08T22:12:59.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:23 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:01 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LGpiAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6XAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFhXX0t0My8qCHdrUMfRwg3B5FPFTjOwddPzvTaHu0t9H1xiDVKOSpDxKItHiqnvYyMKqZVwaC5AIJvYk_bzVt8m7Vil
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 06 Apr 2015 15:01:24 GMT
+      - Mon, 08 Jun 2015 22:13:00 GMT
       Set-Cookie:
-      - BrowserId=vXRooNVARU21TzA74Xl5eg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        05-Jun-2015 15:01:24 GMT
+      - BrowserId=WcrjG8I0RLOTstjj7eQjIg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=50/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Mon, 06 Apr 2015 15:01:24 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:01 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_local_record_with_the_passed_attributes.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_local_record_with_the_passed_attributes.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:17:56 GMT
+      - Mon, 08 Jun 2015 22:12:20 GMT
       Set-Cookie:
-      - BrowserId=MQtGYr90RA2q8ytvgU778w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:17:56 GMT
+      - BrowserId=btwUYR_ITN6Nig5m2sNhzA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652676216","token_type":"Bearer","instance_url":"https://<host>","signature":"QUIZ3gZogRPXpwbGfrjTuY4Gqojjf3jw7vDg9lqABuo=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:17:56 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801540902","token_type":"Bearer","instance_url":"https://<host>","signature":"Zv8kr+5NeNRCOIbvRqOlhSDMAhvbdETYXVKqbunOOWc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:22 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:17:57 GMT
+      - Mon, 08 Jun 2015 22:12:21 GMT
       Set-Cookie:
-      - BrowserId=NRCtBYH6Trij1-9fMU1GTA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:17:57 GMT
+      - BrowserId=7svjHrYASaugzRsG52sbLA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=561/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4bAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoC9AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:17:57 GMT
+      string: '{"id":"a001a000001cF4bAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:22 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoC9AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4bAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,24 +103,24 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:17:58 GMT
+      - Mon, 08 Jun 2015 22:12:21 GMT
       Set-Cookie:
-      - BrowserId=EnmogdcLT8K8KtPem4293Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:17:58 GMT
+      - BrowserId=VE_6USRuQB2a09b0ZNdc7Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=562/15000
+      - api-usage=9/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK"},"Id":"a001a000001ZoC9AAK","SystemModstamp":"2015-05-15T01:17:57.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4bAAE"},"Id":"a001a000001cF4bAAE","SystemModstamp":"2015-06-08T22:12:21.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:17:58 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:22 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:17:59 GMT
+      - Mon, 08 Jun 2015 22:12:21 GMT
       Set-Cookie:
-      - BrowserId=yDVeXGfiT76AwsPcoJseJQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:17:59 GMT
+      - BrowserId=fnHkPV4MS4CHLuHMR6VYeg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=564/15000
+      - api-usage=9/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -162,7 +162,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:17:59 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:23 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4bAAE
     body:
       encoding: UTF-8
       string: '{"Example_Field__c":"Some new text"}'
@@ -186,7 +186,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -197,22 +197,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:00 GMT
+      - Mon, 08 Jun 2015 22:12:21 GMT
       Set-Cookie:
-      - BrowserId=wRFsVIN2QTO0fUXHJzCd9A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:00 GMT
+      - BrowserId=iZJTTnEuRia-OWQktHfBmg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=564/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:00 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:23 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoC9AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4bAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +220,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -231,17 +231,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:01 GMT
+      - Mon, 08 Jun 2015 22:12:21 GMT
       Set-Cookie:
-      - BrowserId=4Tvf3Cv6RBeld7v9vJWaDQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:01 GMT
+      - BrowserId=dczNBij3SuqJT3orSvkPAA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:21 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=565/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:01 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:23 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_record_in_Salesforce_with_the_passed_attributes.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_update_/updates_the_record_in_Salesforce_with_the_passed_attributes.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:02 GMT
+      - Mon, 08 Jun 2015 22:12:22 GMT
       Set-Cookie:
-      - BrowserId=h7xae8D7SxOHJQrjeVn1jg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:02 GMT
+      - BrowserId=-OX1SOrVQgGCd-NmpEfFTg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652682452","token_type":"Bearer","instance_url":"https://<host>","signature":"Qy102BJP9bM487axxMTKz9bQqdSZE51Y979XJlgdJuc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:02 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801542244","token_type":"Bearer","instance_url":"https://<host>","signature":"yJ3IXicqZSl5HVWZGe7xSRSc3584yBHRkgHI8mHraSg=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:23 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:03 GMT
+      - Mon, 08 Jun 2015 22:12:22 GMT
       Set-Cookie:
-      - BrowserId=tvGxdnAUQDGGJbrBwDKRRw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:03 GMT
+      - BrowserId=xOPgIOc0RxSEgpXluXpdrw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=563/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4gAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoCEAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:03 GMT
+      string: '{"id":"a001a000001cF4gAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:23 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4gAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,24 +103,24 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:04 GMT
+      - Mon, 08 Jun 2015 22:12:22 GMT
       Set-Cookie:
-      - BrowserId=qgA5idrxTrSiK77x7z34EA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:04 GMT
+      - BrowserId=qgO_6aa_QCC8yMP4bPKrqA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=567/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:03.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4gAAE"},"Id":"a001a000001cF4gAAE","SystemModstamp":"2015-06-08T22:12:22.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:04 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:24 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:05 GMT
+      - Mon, 08 Jun 2015 22:12:22 GMT
       Set-Cookie:
-      - BrowserId=sk8IatU5T1qnH7uauwqEdw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:05 GMT
+      - BrowserId=D5xvOgjoTlugCXx4oENO3w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=571/15000
+      - api-usage=8/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -162,7 +162,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:05 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:24 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4gAAE
     body:
       encoding: UTF-8
       string: '{"Example_Field__c":"Some new text"}'
@@ -186,7 +186,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -197,22 +197,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:06 GMT
+      - Mon, 08 Jun 2015 22:12:22 GMT
       Set-Cookie:
-      - BrowserId=2BVDCr6rTHCNR8N4b8nsfQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:06 GMT
+      - BrowserId=T8-wWFHkStOFY5sM2TsCPg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:22 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=572/15000
+      - api-usage=8/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:06 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:24 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCEAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4gAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +220,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -231,27 +231,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:07 GMT
+      - Mon, 08 Jun 2015 22:12:23 GMT
       Set-Cookie:
-      - BrowserId=zwq0uOd1TIe7smPhSjY36A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:07 GMT
+      - BrowserId=K2bq4ptvQNKT4s_cpRMKoQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=570/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0"},"Id":"a001a000001ZoCEAA0","SystemModstamp":"2015-05-15T01:18:06.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4gAAE"},"Id":"a001a000001cF4gAAE","SystemModstamp":"2015-06-08T22:12:23.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":"Some new text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:07 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:24 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCEAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4gAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -259,7 +259,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -270,17 +270,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:08 GMT
+      - Mon, 08 Jun 2015 22:12:23 GMT
       Set-Cookie:
-      - BrowserId=s4fi3L3qRruoV-QmcYQy1A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:08 GMT
+      - BrowserId=K3l_KmilQ76cyAdgTpRDeQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:23 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=571/15000
+      - api-usage=9/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:08 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:24 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_updated_internally_/when_another_user_made_the_last_change/returns_false.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_updated_internally_/when_another_user_made_the_last_change/returns_false.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:15:54 GMT
+      Set-Cookie:
+      - BrowserId=FCuJCit1TdWDicYxh_xT2w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:15:54 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801754892","token_type":"Bearer","instance_url":"https://<host>","signature":"iJ/WobYjcaXODnovUXllGuDp0CwR4qKJABBKGwnxN2M=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:15:56 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:15:55 GMT
+      Set-Cookie:
+      - BrowserId=ZCpQ-nrETwe00o3Uf8IEcw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:15:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=308/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"limits":"/services/data/<api_version>/limits","sobjects":"/services/data/<api_version>/sobjects","connect":"/services/data/<api_version>/connect","query":"/services/data/<api_version>/query","theme":"/services/data/<api_version>/theme","queryAll":"/services/data/<api_version>/queryAll","tooling":"/services/data/<api_version>/tooling","chatter":"/services/data/<api_version>/chatter","analytics":"/services/data/<api_version>/analytics","recent":"/services/data/<api_version>/recent","commerce":"/services/data/<api_version>/commerce","licensing":"/services/data/<api_version>/licensing","identity":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","flexiPage":"/services/data/<api_version>/flexiPage","search":"/services/data/<api_version>/search","quickActions":"/services/data/<api_version>/quickActions","appMenu":"/services/data/<api_version>/appMenu"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:15:56 GMT
+- request:
+    method: get
+    uri: https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:15:55 GMT
+      - Mon, 08 Jun 2015 22:15:55 GMT
+      Set-Cookie:
+      - BrowserId=gTYPyIerS0SwrgU5lXs_Dg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:15:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","asserted_user":true,"user_id":"0051a000000UGT8AAO","organization_id":"00D1a000000H3O9EAK","username":"andrew+salesforce@tablexi.com","nick_name":"andrew+salesforce1.42656567106328E12","display_name":"Andrew
+        Horner","email":"andrew@tablexi.com","email_verified":true,"first_name":"Andrew","last_name":"Horner","timezone":"America/Los_Angeles","photos":{"picture":"https://c.na24.content.force.com/profilephoto/005/F","thumbnail":"https://c.na24.content.force.com/profilephoto/005/T"},"addr_street":null,"addr_city":null,"addr_state":null,"addr_country":"US","addr_zip":"60661","mobile_phone":null,"mobile_phone_verified":false,"status":{"created_date":null,"body":null},"urls":{"enterprise":"https://<host>/services/Soap/c/{version}/00D1a000000H3O9","metadata":"https://<host>/services/Soap/m/{version}/00D1a000000H3O9","partner":"https://<host>/services/Soap/u/{version}/00D1a000000H3O9","rest":"https://<host>/services/data/v{version}/","sobjects":"https://<host>/services/data/v{version}/sobjects/","search":"https://<host>/services/data/v{version}/search/","query":"https://<host>/services/data/v{version}/query/","recent":"https://<host>/services/data/v{version}/recent/","profile":"https://<host>/0051a000000UGT8AAO","feeds":"https://<host>/services/data/v{version}/chatter/feeds","groups":"https://<host>/services/data/v{version}/chatter/groups","users":"https://<host>/services/data/v{version}/chatter/users","feed_items":"https://<host>/services/data/v{version}/chatter/feed-items"},"active":true,"user_type":"STANDARD","language":"en_US","locale":"en_US","utcOffset":-28800000,"last_modified_date":"2015-03-17T04:14:23.000+0000","is_app_installed":true}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:15:56 GMT
+recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Instances_Salesforce/_updated_internally_/when_our_client_made_the_last_change/returns_true.yml
+++ b/test/cassettes/Restforce_DB_Instances_Salesforce/_updated_internally_/when_our_client_made_the_last_change/returns_true.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:53 GMT
+      - Mon, 08 Jun 2015 22:13:26 GMT
       Set-Cookie:
-      - BrowserId=0NlyhtOHR0-4e2AC-d1GfA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:53 GMT
+      - BrowserId=wzRlmgWSSsaLHpef_Dn3oQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,15 +37,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801573462","token_type":"Bearer","instance_url":"https://<host>","signature":"FlY3hhTuJy9ykAgikv7cWVvC7sKFAhQ22eAUkAwU+bI=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801606202","token_type":"Bearer","instance_url":"https://<host>","signature":"AvAvqjEn5CywCli3OOkNnhZjXFr4BC3QG6Z7nxJ60Xs=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:55 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:27 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
+      string: '{"Name":"Sample object"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:53 GMT
+      - Mon, 08 Jun 2015 22:13:26 GMT
       Set-Cookie:
-      - BrowserId=CXFKGBfoSzKCzwr4nIK13Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:53 GMT
+      - BrowserId=rj0_5-jkQx2OiYJb-3d77A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=34/15000
+      - api-usage=129/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4mAAE"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7pAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001cF4mAAE","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF7pAAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:55 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:27 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7pAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:53 GMT
+      - Mon, 08 Jun 2015 22:13:26 GMT
       Set-Cookie:
-      - BrowserId=qj9o68k-STORM1KooMQhEQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:53 GMT
+      - BrowserId=gJsxwP-4TuORfqe22tSf4A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=30/15000
+      - api-usage=127/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4mAAE"},"Id":"a001a000001cF4mAAE","SystemModstamp":"2015-06-08T22:12:53.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
-        object","Example_Field__c":"Some sample text"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7pAAE"},"Id":"a001a000001cF7pAAE","SystemModstamp":"2015-06-08T22:13:26.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
+        object","Example_Field__c":null}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:55 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:28 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4mAAE
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7pAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:53 GMT
+      - Mon, 08 Jun 2015 22:13:26 GMT
       Set-Cookie:
-      - BrowserId=seq-JwnFRgGdp-jPKTimbA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:53 GMT
+      - BrowserId=p0isIyOSQ1ipnQJHMbL6ng;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:26 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=31/15000
+      - api-usage=130/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:55 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:28 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_all/returns_a_list_of_the_existing_records_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_all/returns_a_list_of_the_existing_records_in_Salesforce.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:42:48 GMT
+      - Mon, 08 Jun 2015 22:40:18 GMT
       Set-Cookie:
-      - BrowserId=8KpISBKERgy2g417EyCKJg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:42:48 GMT
+      - BrowserId=oSpeGKWuSW26Uqc9FyCgRA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:40:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910168476","token_type":"Bearer","instance_url":"https://<host>","signature":"NrGCnWPtuW3F1C8VyTV7HxO5FJosOMjVa/Mp89FnAAE=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:42:48 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433803218747","token_type":"Bearer","instance_url":"https://<host>","signature":"aR5Jk7B9ChsBjY5JBQq7jykirRSi/qJf4OBGhCngDn4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:40:20 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:42:49 GMT
+      - Mon, 08 Jun 2015 22:40:18 GMT
       Set-Cookie:
-      - BrowserId=ZOjtoPSFTMiVnF96dDQ83w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:42:49 GMT
+      - BrowserId=0zy1fpPyQGC3XqECVRvM7g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:40:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=310/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoJAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LFfsAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:42:49 GMT
+      string: '{"id":"a001a000001cFoJAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:40:20 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:42:50 GMT
+      - Mon, 08 Jun 2015 22:40:19 GMT
       Set-Cookie:
-      - BrowserId=9SFfcrRjRlqc6KnrgdGKyg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:42:50 GMT
+      - BrowserId=IHddJ-W1Tqing_2K26NY8A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:40:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=310/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG"},"Id":"a001a000001LFfsAAG","SystemModstamp":"2015-04-01T17:42:49.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoJAAU"},"Id":"a001a000001cFoJAAU","SystemModstamp":"2015-06-08T22:40:18.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:42:50 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:40:20 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFfsAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoJAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:42:51 GMT
+      - Mon, 08 Jun 2015 22:40:19 GMT
       Set-Cookie:
-      - BrowserId=aX4v74VsTo2dEyXmodEWrw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:42:51 GMT
+      - BrowserId=IUNnRQRdQ_KGt1iNymVUbA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:40:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=11/15000
+      - api-usage=310/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:42:52 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:40:20 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/updates_the_database_record_with_the_Salesforce_record_s_ID.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_create_/updates_the_database_record_with_the_Salesforce_record_s_ID.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:30 GMT
+      - Mon, 08 Jun 2015 22:12:14 GMT
       Set-Cookie:
-      - BrowserId=havKI4cqR_yfs4NSO24Zdw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:30 GMT
+      - BrowserId=DIaURZ3jT4CVeG4rfLqn4w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431654450580","token_type":"Bearer","instance_url":"https://<host>","signature":"cZdZrQXtuULSChiTBZnelwS3jngapPntG4i3duMQyAc=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:30 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801534584","token_type":"Bearer","instance_url":"https://<host>","signature":"/olfs0f84upBPOHPa76jzH1HYJM6I5S7gnRKv4sqZSI=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:16 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -50,7 +50,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -61,14 +61,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:32 GMT
+      - Mon, 08 Jun 2015 22:12:14 GMT
       Set-Cookie:
-      - BrowserId=QaXcFpeiS8OmjIEXDRGaaw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:32 GMT
+      - BrowserId=lXGGn_x7QUucdUpDx085Rw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=810/15000
+      - api-usage=6/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -81,7 +81,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -90,9 +90,9 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:32 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:16 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -105,7 +105,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -116,28 +116,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:33 GMT
+      - Mon, 08 Jun 2015 22:12:14 GMT
       Set-Cookie:
-      - BrowserId=vOjGt0UAQAWVUS6xKpmDgg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:33 GMT
+      - BrowserId=z6sxw7h2QJaN05Om5s9LOw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:14 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=810/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4CAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoF3AAK","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:33 GMT
+      string: '{"id":"a001a000001cF4CAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:16 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoF3AAK%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4CAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -145,7 +145,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -156,27 +156,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:34 GMT
+      - Mon, 08 Jun 2015 22:12:15 GMT
       Set-Cookie:
-      - BrowserId=UaDWB8KaQT6XiM7K_C1Ybg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:34 GMT
+      - BrowserId=zyBB9LJRRB63i6kQ8bFBUA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=810/15000
+      - api-usage=6/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK"},"Id":"a001a000001ZoF3AAK","SystemModstamp":"2015-05-15T01:47:33.000+0000","Name":"Something","Example_Field__c":"Something
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4CAAU"},"Id":"a001a000001cF4CAAU","SystemModstamp":"2015-06-08T22:12:14.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Something","Example_Field__c":"Something
         else"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:34 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:16 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoF3AAK
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4CAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -184,7 +184,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -195,17 +195,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:47:35 GMT
+      - Mon, 08 Jun 2015 22:12:15 GMT
       Set-Cookie:
-      - BrowserId=2WnEgBaUSKCuIBSVVzfn1w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:47:35 GMT
+      - BrowserId=PVq3Sh4mQ5eCAgP9l45GZw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=810/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:47:35 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:17 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/finds_existing_records_in_Salesforce.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/finds_existing_records_in_Salesforce.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:05 GMT
+      - Mon, 08 Jun 2015 22:12:51 GMT
       Set-Cookie:
-      - BrowserId=bsw5P_ZZSiy_gwbM9k8EQA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:05 GMT
+      - BrowserId=jUl0_DR7TGCPuR1nCFECcQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427365205725","token_type":"Bearer","instance_url":"https://<host>","signature":"WPsgaBgCRYGOEsFjS+M6yxlxgnbi9SoEZQtDGGzQFC0=","access_token":"00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ"}'
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:05 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801571496","token_type":"Bearer","instance_url":"https://<host>","signature":"Iy2+FAcAFV0WmQ+5D/QmRmJmUuLpGISO3r2Y9bB5494=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:53 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:06 GMT
+      - Mon, 08 Jun 2015 22:12:51 GMT
       Set-Cookie:
-      - BrowserId=nTP-A_VHSgC6oqTWS-wCig;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:06 GMT
+      - BrowserId=_AI78zZTRp6y1DUIqNcK_w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/15000
+      - api-usage=31/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF63AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001J1AWAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:06 GMT
+      string: '{"id":"a001a000001cF63AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:53 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001J1AWAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF63AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:08 GMT
+      - Mon, 08 Jun 2015 22:12:51 GMT
       Set-Cookie:
-      - BrowserId=eX-DZzdYRBS9_DkJArE-Jw;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:08 GMT
+      - BrowserId=u0ipO08ZT66xAjlpSjtDgg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=34/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0"},"Id":"a001a000001J1AWAA0","SystemModstamp":"2015-03-26T10:20:06.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF63AAE"},"Id":"a001a000001cF63AAE","SystemModstamp":"2015-06-08T22:12:51.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:08 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:53 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001J1AWAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF63AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:09 GMT
+      - Mon, 08 Jun 2015 22:12:51 GMT
       Set-Cookie:
-      - BrowserId=DoYedeUrRv6o7ha8o-kGLg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:09 GMT
+      - BrowserId=HE8ZjzOOSa6RLxG4khPyyg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=30/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:09 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:53 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_does_not_meet_the_conditions/does_not_find_the_record.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_does_not_meet_the_conditions/does_not_find_the_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:22 GMT
+      - Mon, 08 Jun 2015 22:12:56 GMT
       Set-Cookie:
-      - BrowserId=y9Xwyc7sRiS-SYlyinh-gg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:22 GMT
+      - BrowserId=YTE2T9uTSlqxPYQZMB3dWg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910682943","token_type":"Bearer","instance_url":"https://<host>","signature":"XV2VCZfDmhSb6On2Br5cxsAz/NvNH3JlkOdbLX/clPY=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:23 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801576351","token_type":"Bearer","instance_url":"https://<host>","signature":"LDM/LILePKsWFYJhzqmyMhvBzfJ1B8Z1WQxcnjKcAVo=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:57 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:23 GMT
+      - Mon, 08 Jun 2015 22:12:56 GMT
       Set-Cookie:
-      - BrowserId=Kfkv4LuQR3-iN46hIDKtug;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:23 GMT
+      - BrowserId=cQEVAygNROS47EHlfvPMvg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=41/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgMAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6NAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LFgMAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:24 GMT
+      string: '{"id":"a001a000001cF6NAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:58 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgMAAW%27%20and%20Visible__c%20=%20TRUE
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6NAAU%27%20and%20Visible__c%20=%20TRUE
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,14 +103,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:25 GMT
+      - Mon, 08 Jun 2015 22:12:56 GMT
       Set-Cookie:
-      - BrowserId=YzZvI_D3ShuJoLZb3ROxkQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:25 GMT
+      - BrowserId=Q260OW94SF69d9b8YwRMqg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=42/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -118,11 +118,11 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:25 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:58 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgMAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6NAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -130,7 +130,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -141,17 +141,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:26 GMT
+      - Mon, 08 Jun 2015 22:12:56 GMT
       Set-Cookie:
-      - BrowserId=KChk1bwkRkeQl0fwoxj5TQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:26 GMT
+      - BrowserId=ESjWxQg0QbeH4QLBGT5vVg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=34/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:26 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:58 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_meets_the_conditions/finds_the_record.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/given_a_set_of_mapping_conditions/when_a_record_meets_the_conditions/finds_the_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:18 GMT
+      - Mon, 08 Jun 2015 22:12:47 GMT
       Set-Cookie:
-      - BrowserId=-n50WpbhSAmLOfePSfw1JA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:18 GMT
+      - BrowserId=56uPkmbsTvukTYX7MCUukA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427910678934","token_type":"Bearer","instance_url":"https://<host>","signature":"r7U6IsW9cCkVABj4E879KcDbgJZSkrit4swb8PBuwtw=","access_token":"00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW"}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:19 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801567156","token_type":"Bearer","instance_url":"https://<host>","signature":"GSemLQvMAoD46gLkJNOkH0KnVToGQNSx2X3+AaYMjTA=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:19 GMT
+      - Mon, 08 Jun 2015 22:12:47 GMT
       Set-Cookie:
-      - BrowserId=uBlo3fFFSeOgxVD78aQnJg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:19 GMT
+      - BrowserId=7VyNkuwOTI6tmzeOX00-kg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=22/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF51AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LFgHAAW","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:20 GMT
+      string: '{"id":"a001a000001cF51AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LFgHAAW%27%20and%20Visible__c%20=%20TRUE
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF51AAE%27%20and%20Visible__c%20=%20TRUE
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:20 GMT
+      - Mon, 08 Jun 2015 22:12:47 GMT
       Set-Cookie:
-      - BrowserId=0luURef9R7uia6N7fuHh9w;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:20 GMT
+      - BrowserId=xLSPXfcnR3-Vrmdu9L0dAg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=18/15000
+      - api-usage=26/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW"},"Id":"a001a000001LFgHAAW","SystemModstamp":"2015-04-01T17:51:19.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF51AAE"},"Id":"a001a000001cF51AAE","SystemModstamp":"2015-06-08T22:12:47.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:21 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:49 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LFgHAAW
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF51AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQKZwdgw8XRPQOd9_ipgseq9yxNqcklYDcsxnqhIM56FN53.IU986f9x29rxVXv5E_w_ReuA_8Q2P_TTVjLPBPmxzVeiW
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 01 Apr 2015 17:51:21 GMT
+      - Mon, 08 Jun 2015 22:12:47 GMT
       Set-Cookie:
-      - BrowserId=WdYv53V1RZqLRR4JQ5mc5A;Path=/;Domain=.salesforce.com;Expires=Sun,
-        31-May-2015 17:51:21 GMT
+      - BrowserId=Q3C6DYCmRaeYYudWWb3T8A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=17/15000
+      - api-usage=26/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 01 Apr 2015 17:51:22 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:49 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/returns_nil_when_no_matching_record_exists.yml
+++ b/test/cassettes/Restforce_DB_RecordTypes_Salesforce/_find/returns_nil_when_no_matching_record_exists.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:10 GMT
+      - Mon, 08 Jun 2015 22:12:50 GMT
       Set-Cookie:
-      - BrowserId=Gwu4EIW2SumjAjuGLUnszQ;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:10 GMT
+      - BrowserId=40474714QPmq-j6O8bm4CA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,12 +37,12 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1427365210282","token_type":"Bearer","instance_url":"https://<host>","signature":"1SLB9/QWDmq3AVQgeB8YKrzTdsqbLN8vSCZi8+bmhN0=","access_token":"00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ"}'
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:10 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801571043","token_type":"Bearer","instance_url":"https://<host>","signature":"D7YTtCzChqdH0jhBWvD5UzaykM2OHgDK4uwwQHnbzKA=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:52 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001E1vFAKE%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001E1vFAKE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -50,7 +50,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQFqDs34WtnS6RDwxyGdLSPYE_cFTuNjjnDvX2HbNhGMu917m6JyqchGFbdiOruyd5Z.w7uN.ogsJF4_8TMMzdt2fw7OZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -61,14 +61,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 26 Mar 2015 10:20:11 GMT
+      - Mon, 08 Jun 2015 22:12:51 GMT
       Set-Cookie:
-      - BrowserId=Q7PphvNzSDaluXAo8GemiA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        25-May-2015 10:20:11 GMT
+      - BrowserId=KIiDdonNSYGSk_Nqo6-HRA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=3/15000
+      - api-usage=29/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -76,6 +76,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"totalSize":0,"done":true,"records":[]}'
-    http_version:
-  recorded_at: Thu, 26 Mar 2015 10:20:11 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/wants_to_build_a_new_matching_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/wants_to_build_a_new_matching_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:20 GMT
+      - Mon, 08 Jun 2015 22:12:18 GMT
       Set-Cookie:
-      - BrowserId=aV1yozgjTVWf7NTdcekyKQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:20 GMT
+      - BrowserId=ze8xkaHNQHese2o9BBIbiA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428513920164","token_type":"Bearer","instance_url":"https://<host>","signature":"+9Ohy1Rt/hV2LV72iFHN4G0osOsG5BWr/EnsA2it878=","access_token":"00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe"}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801538837","token_type":"Bearer","instance_url":"https://<host>","signature":"KH757+hMtd+Eypamufr+fntLggiLePD9YQKlQRDk5dk=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:20 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:20 GMT
+      - Mon, 08 Jun 2015 22:12:18 GMT
       Set-Cookie:
-      - BrowserId=bweRzNnuS5yGi0KPQtNPlw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:20 GMT
+      - BrowserId=nyBefqm8R_6dt2KhC8c8Ew;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:18 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4RAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LMs9AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
+      string: '{"id":"a001a000001cF4RAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:20 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs9AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4RAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:20 GMT
+      - Mon, 08 Jun 2015 22:12:19 GMT
       Set-Cookie:
-      - BrowserId=LdEHnhcdRxGe-GXkxf1njw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:20 GMT
+      - BrowserId=UAaoonInTT2x00hAYeXBQA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG"},"Id":"a001a000001LMs9AAG","SystemModstamp":"2015-04-08T17:25:20.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4RAAU"},"Id":"a001a000001cF4RAAU","SystemModstamp":"2015-06-08T22:12:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:20 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs9AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4RAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:20 GMT
+      - Mon, 08 Jun 2015 22:12:19 GMT
       Set-Cookie:
-      - BrowserId=vEmT_p9fRFiuV4_9cudymw;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:20 GMT
+      - BrowserId=shcjx_HqTtG4LQaTC7Itng;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=6/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:21 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/with_a_corresponding_database_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Always/_build_/given_a_Salesforce_record/with_a_corresponding_database_record/does_not_want_to_build_a_new_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:17 GMT
+      - Mon, 08 Jun 2015 22:12:36 GMT
       Set-Cookie:
-      - BrowserId=lengI2EHTRub2Ko8hohJlQ;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:17 GMT
+      - BrowserId=2igX9rxVQMKEHAniTZpGkg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428513917270","token_type":"Bearer","instance_url":"https://<host>","signature":"EQGJyzSNyv8NhiCakDKNBRYnVOwnkS5/GgopPeymCdM=","access_token":"00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe"}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801556727","token_type":"Bearer","instance_url":"https://<host>","signature":"eewurQWqiWiaAu2PlxlL9PXBaq7A2+1BmSUWjnazmsY=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:38 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:17 GMT
+      - Mon, 08 Jun 2015 22:12:36 GMT
       Set-Cookie:
-      - BrowserId=zaP7cAcjRAO83Rd04ogCbg;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:17 GMT
+      - BrowserId=bhl_qADcQeCW-bB-nwS6BQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:36 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=10/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5PAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LMs4AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
+      string: '{"id":"a001a000001cF5PAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:38 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LMs4AAG%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5PAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:17 GMT
+      - Mon, 08 Jun 2015 22:12:37 GMT
       Set-Cookie:
-      - BrowserId=WXSf9tl1QHmxrtYD_ZRVmA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:17 GMT
+      - BrowserId=_tzcuzFZS0ekE_NsUyn9kg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=12/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG"},"Id":"a001a000001LMs4AAG","SystemModstamp":"2015-04-08T17:25:17.000+0000","Name":"Sample
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5PAAU"},"Id":"a001a000001cF5PAAU","SystemModstamp":"2015-06-08T22:12:36.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Sample
         object","Example_Field__c":null}]}'
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:16 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:38 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LMs4AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5PAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQCyefAUUsnWlCVp8nuCPw5FHOg4Bv_Grcp4GTCMkt22gpGUL_iimYlj.5dHJYoGbAKCuPttEXOKeigHMy9VPNErhVDRe
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,17 +142,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 08 Apr 2015 17:25:18 GMT
+      - Mon, 08 Jun 2015 22:12:37 GMT
       Set-Cookie:
-      - BrowserId=Jr37xurySTWA9GLgtkUEsA;Path=/;Domain=.salesforce.com;Expires=Sun,
-        07-Jun-2015 17:25:18 GMT
+      - BrowserId=n3l2kyR6S0WWQdsoy0V0BA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:37 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=1/15000
+      - api-usage=10/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Wed, 08 Apr 2015 17:25:17 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:38 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_a_synchronized_association_record/wants_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_a_synchronized_association_record/wants_to_build_a_new_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:49 GMT
+      - Mon, 08 Jun 2015 22:13:03 GMT
       Set-Cookie:
-      - BrowserId=rVlbGvXPT7qWc0wAZ9dDKA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:49 GMT
+      - BrowserId=dzASMlLMQxe60xydfEghRQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734569662","token_type":"Bearer","instance_url":"https://<host>","signature":"9ywQmIx1Es8WNVEkdv039RH5e4G8DGM53aUnGnPNLcA=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:50 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801583214","token_type":"Bearer","instance_url":"https://<host>","signature":"BuXclflYoZPCuAYVJb+RJl3uWR8fAaM1A/tkkLYMqNc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:04 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:50 GMT
+      - Mon, 08 Jun 2015 22:13:03 GMT
       Set-Cookie:
-      - BrowserId=1DNCHkUnSvO9FLOQv72lyQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:50 GMT
+      - BrowserId=ehli4rtgTti2ag1cbyGTvg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=48/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgaAAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6mAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXgaAAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:51 GMT
+      string: '{"id":"a001a000001cF6mAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:04 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"CustomObject__c":"a001a000001LXgaAAG"}'
+      string: '{"CustomObject__c":"a001a000001cF6mAAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:51 GMT
+      - Mon, 08 Jun 2015 22:13:03 GMT
       Set-Cookie:
-      - BrowserId=m3w01ba-S7uqFZKvxYImAQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:51 GMT
+      - BrowserId=hyVblq_vQFuYht43355xsA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=49/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPxAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gyxHAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:52 GMT
+      string: '{"id":"a011a000001FiPxAAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:05 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000001FiPxAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:52 GMT
+      - Mon, 08 Jun 2015 22:13:03 GMT
       Set-Cookie:
-      - BrowserId=y83CgH9BTcGvuTYM67oIVQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:52 GMT
+      - BrowserId=8kYLpE1sSAO_agZ-XtHllw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=41/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:53 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPxAAK"},"Id":"a011a000001FiPxAAK","SystemModstamp":"2015-06-08T22:13:03.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiPx","CustomObject__c":"a001a000001cF6mAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:05 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxHAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000001FiPxAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:53 GMT
+      - Mon, 08 Jun 2015 22:13:03 GMT
       Set-Cookie:
-      - BrowserId=ctRxay3wQ7GMAqPQrFUgSw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:53 GMT
+      - BrowserId=NAsbnjd1SMOsoQ7XBEmOqA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=46/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ"},"Id":"a011a000000gyxHAAQ","SystemModstamp":"2015-04-11T06:42:51.000+0000","Name":"a011a000000gyxH","CustomObject__c":"a001a000001LXgaAAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:54 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPxAAK"},"Id":"a011a000001FiPxAAK","SystemModstamp":"2015-06-08T22:13:03.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiPx","CustomObject__c":"a001a000001cF6mAAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:05 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXgaAAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6mAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:56 GMT
+      - Mon, 08 Jun 2015 22:13:04 GMT
       Set-Cookie:
-      - BrowserId=lQO0Yc0DQH2t_bd1UL1z7A;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:56 GMT
+      - BrowserId=Oo7ZEGffSrmuvI2yxir2Gg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=44/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:56 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:05 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxHAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPxAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,14 +255,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:57 GMT
+      - Mon, 08 Jun 2015 22:13:04 GMT
       Set-Cookie:
-      - BrowserId=CEWJ3S0oSt-5SOrlAjIx3w;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:57 GMT
+      - BrowserId=lwpikd4HT76KxkvfPMk0oA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=45/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -270,6 +270,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:58 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:06 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_an_existing_database_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_an_existing_database_record/does_not_want_to_build_a_new_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:08 GMT
+      - Mon, 08 Jun 2015 22:13:33 GMT
       Set-Cookie:
-      - BrowserId=kncqiWysTfyQJadJaRa7UA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:08 GMT
+      - BrowserId=OjQGiPOrTbuLeuz-yWP0iQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734589061","token_type":"Bearer","instance_url":"https://<host>","signature":"m7X5wKIMbwHnUlVdcdtxbIwCECW4Yq8Q91BjPfqF68g=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:09 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801613300","token_type":"Bearer","instance_url":"https://<host>","signature":"gjxMjr/ufXUNlK0GWjG866Yt3rOgHjnWD3PIlKmBqTs=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:34 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:10 GMT
+      - Mon, 08 Jun 2015 22:13:33 GMT
       Set-Cookie:
-      - BrowserId=bTsYI43_Tv-pk6GLS7lg2g;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:10 GMT
+      - BrowserId=Jx2MWqOzTP2Wxol_tLUx6Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=134/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq7AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF84AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXq7AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:10 GMT
+      string: '{"id":"a001a000001cF84AAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:35 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"CustomObject__c":"a001a000001LXq7AAG"}'
+      string: '{"CustomObject__c":"a001a000001cF84AAE"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:11 GMT
+      - Mon, 08 Jun 2015 22:13:33 GMT
       Set-Cookie:
-      - BrowserId=Lhfp2cMxRoSCH0nS76hilw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:11 GMT
+      - BrowserId=kNNkvGLyRMO6pQN6ay3zVA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=131/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQbAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gyxRAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:11 GMT
+      string: '{"id":"a011a000001FiQbAAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:35 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxRAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000001FiQbAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:12 GMT
+      - Mon, 08 Jun 2015 22:13:33 GMT
       Set-Cookie:
-      - BrowserId=YS6CyteqTZKGh7PRTbMr0Q;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:12 GMT
+      - BrowserId=AZtXEE80Spq1AjqzmGMMoQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:33 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=131/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ"},"Id":"a011a000000gyxRAAQ","SystemModstamp":"2015-04-11T06:43:11.000+0000","Name":"a011a000000gyxR","CustomObject__c":"a001a000001LXq7AAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:12 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQbAAK"},"Id":"a011a000001FiQbAAK","SystemModstamp":"2015-06-08T22:13:33.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiQb","CustomObject__c":"a001a000001cF84AAE"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:35 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq7AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF84AAE
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,22 +183,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:13 GMT
+      - Mon, 08 Jun 2015 22:13:34 GMT
       Set-Cookie:
-      - BrowserId=Awcxw7G1SXiCTkdZWqE9OA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:13 GMT
+      - BrowserId=Do_hGHGVTvKVTFnj3elr6g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=155/15000
+      - api-usage=136/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:13 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:35 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxRAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiQbAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -206,7 +206,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -217,14 +217,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:14 GMT
+      - Mon, 08 Jun 2015 22:13:34 GMT
       Set-Cookie:
-      - BrowserId=SRD1PfCKT0G8l0jXm4cOVQ;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:14 GMT
+      - BrowserId=LMjwAmANT-yiOPzL6A7Zfw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:34 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=155/15000
+      - api-usage=138/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -232,6 +232,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:15 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:36 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_no_synchronized_association_record/does_not_want_to_build_a_new_record.yml
+++ b/test/cassettes/Restforce_DB_Strategies_Associated/_build_/given_an_inverse_mapping/with_no_synchronized_association_record/does_not_want_to_build_a_new_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:42:59 GMT
+      - Mon, 08 Jun 2015 22:12:15 GMT
       Set-Cookie:
-      - BrowserId=u-7EnRPMQEOh3y4FZAIEHg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:42:59 GMT
+      - BrowserId=b249nkLHTkOlmMxdg1jR7g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428734579132","token_type":"Bearer","instance_url":"https://<host>","signature":"22v+bPU50gx+t0KAwCUnZYB07Lyh/CzrwLhWUeAOwQs=","access_token":"00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx"}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:42:59 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801535781","token_type":"Bearer","instance_url":"https://<host>","signature":"oNi9HB+lnY4h1s4exktZvQyzwWDzt3DQ8v7hWQ7WmDc=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:17 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,38 +63,38 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:00 GMT
+      - Mon, 08 Jun 2015 22:12:15 GMT
       Set-Cookie:
-      - BrowserId=iL1n2l9wSwa25t41vHCoEg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:00 GMT
+      - BrowserId=SRPqp0RJStqaT_uNAZ807Q;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:15 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq2AAG"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4HAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXq2AAG","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:00 GMT
+      string: '{"id":"a001a000001cF4HAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:17 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c
     body:
       encoding: UTF-8
-      string: '{"CustomObject__c":"a001a000001LXq2AAG"}'
+      string: '{"CustomObject__c":"a001a000001cF4HAAU"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -105,28 +105,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:01 GMT
+      - Mon, 08 Jun 2015 22:12:16 GMT
       Set-Cookie:
-      - BrowserId=2y5mWp0eR0ighxHLFk0XPg;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:01 GMT
+      - BrowserId=y22DrGUxS1K6GnnPUKlm-g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=7/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"
+      - "/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPdAAK"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a011a000000gyxMAAQ","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:01 GMT
+      string: '{"id":"a011a000001FiPdAAK","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000001FiPdAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -145,26 +145,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:02 GMT
+      - Mon, 08 Jun 2015 22:12:16 GMT
       Set-Cookie:
-      - BrowserId=sRFL1Q8DQm-fm1RgKmjBIw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:02 GMT
+      - BrowserId=8nCiZecRR9ebP1GFwv-IVQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:02 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPdAAK"},"Id":"a011a000001FiPdAAK","SystemModstamp":"2015-06-08T22:12:16.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiPd","CustomObject__c":"a001a000001cF4HAAU"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:17 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000000gyxMAAQ%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20CustomObject__c%20from%20CustomObjectDetail__c%20where%20Id%20=%20%27a011a000001FiPdAAK%27
     body:
       encoding: US-ASCII
       string: ''
@@ -172,7 +172,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -183,26 +183,26 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:03 GMT
+      - Mon, 08 Jun 2015 22:12:16 GMT
       Set-Cookie:
-      - BrowserId=BKTUJbnMQMyam6jgObGEQA;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:03 GMT
+      - BrowserId=sEvVdhGjTzq4Fd2NF-3Tyw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=153/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ"},"Id":"a011a000000gyxMAAQ","SystemModstamp":"2015-04-11T06:43:01.000+0000","Name":"a011a000000gyxM","CustomObject__c":"a001a000001LXq2AAG"}]}'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:04 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObjectDetail__c","url":"/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPdAAK"},"Id":"a011a000001FiPdAAK","SystemModstamp":"2015-06-08T22:12:16.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a011a000001FiPd","CustomObject__c":"a001a000001cF4HAAU"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXq2AAG
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4HAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -221,22 +221,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:04 GMT
+      - Mon, 08 Jun 2015 22:12:16 GMT
       Set-Cookie:
-      - BrowserId=ADr5HBxESOiPA9wrwXFnmw;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:04 GMT
+      - BrowserId=XvMgq4viRo2akdr8SEGgOA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:05 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:18 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000000gyxMAAQ
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObjectDetail__c/a011a000001FiPdAAK
     body:
       encoding: US-ASCII
       string: ''
@@ -244,7 +244,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIyTuSKn1TCR6oX6k4qCgK2hb4xjUYNDY3Jrprus.eG.vfY9WTiqMBJovOXyNilB_lzfaHH0cbBzfmw1gYcg7_8PyEzx
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -255,14 +255,14 @@ http_interactions:
       message: Not Found
     headers:
       Date:
-      - Sat, 11 Apr 2015 06:43:05 GMT
+      - Mon, 08 Jun 2015 22:12:16 GMT
       Set-Cookie:
-      - BrowserId=Ch5ajP1eRXSAfvcy_VMG0g;Path=/;Domain=.salesforce.com;Expires=Wed,
-        10-Jun-2015 06:43:05 GMT
+      - BrowserId=WfQQEGbsRNqI6P-L07-IAw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:16 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=154/15000
+      - api-usage=7/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
@@ -270,6 +270,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"message":"entity is deleted","errorCode":"ENTITY_IS_DELETED","fields":[]}]'
-    http_version:
-  recorded_at: Sat, 11 Apr 2015 06:43:06 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:18 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:17 GMT
+      - Mon, 08 Jun 2015 22:12:40 GMT
       Set-Cookie:
-      - BrowserId=u1cZmlrlQ7KTPFki9xLTGw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:17 GMT
+      - BrowserId=EICIxCMNSKSAlHccWJg3Ig;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652697454","token_type":"Bearer","instance_url":"https://<host>","signature":"IGzFX5UxywYL5AYcXcaWnSqrk/eM5WjIUh/iQvFsr58=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:17 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801560847","token_type":"Bearer","instance_url":"https://<host>","signature":"8tKfEEtLt2Iwt8KrmngoJD9FfTXYHWDgAVVg0ioS+G8=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:42 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:18 GMT
+      - Mon, 08 Jun 2015 22:12:41 GMT
       Set-Cookie:
-      - BrowserId=QqZ8-kaDRWa8UsrnyWhLow;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:18 GMT
+      - BrowserId=vyYTDjchQYK8Tpn_x_qGGw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=578/15000
+      - api-usage=19/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5eAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoCOAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:18 GMT
+      string: '{"id":"a001a000001cF5eAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:42 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCOAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5eAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,24 +103,100 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:19 GMT
+      - Mon, 08 Jun 2015 22:12:41 GMT
       Set-Cookie:
-      - BrowserId=FL1bBcssSP2poI6ue6Vxrg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:19 GMT
+      - BrowserId=ccmpbm-_Tg2lXh65k-aPEg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=580/15000
+      - api-usage=17/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0"},"Id":"a001a000001ZoCOAA0","SystemModstamp":"2015-05-15T01:18:18.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5eAAE"},"Id":"a001a000001cF5eAAE","SystemModstamp":"2015-06-08T22:12:41.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:19 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:42 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:12:41 GMT
+      Set-Cookie:
+      - BrowserId=2VLqj7B2Ra6BFpuhUNvDKw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=22/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"limits":"/services/data/<api_version>/limits","sobjects":"/services/data/<api_version>/sobjects","connect":"/services/data/<api_version>/connect","query":"/services/data/<api_version>/query","theme":"/services/data/<api_version>/theme","queryAll":"/services/data/<api_version>/queryAll","tooling":"/services/data/<api_version>/tooling","chatter":"/services/data/<api_version>/chatter","analytics":"/services/data/<api_version>/analytics","recent":"/services/data/<api_version>/recent","commerce":"/services/data/<api_version>/commerce","licensing":"/services/data/<api_version>/licensing","identity":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","flexiPage":"/services/data/<api_version>/flexiPage","search":"/services/data/<api_version>/search","quickActions":"/services/data/<api_version>/quickActions","appMenu":"/services/data/<api_version>/appMenu"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:43 GMT
+- request:
+    method: get
+    uri: https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:12:41 GMT
+      - Mon, 08 Jun 2015 22:12:41 GMT
+      Set-Cookie:
+      - BrowserId=g4jncCslRPWIUPVsiJLIXQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","asserted_user":true,"user_id":"0051a000000UGT8AAO","organization_id":"00D1a000000H3O9EAK","username":"andrew+salesforce@tablexi.com","nick_name":"andrew+salesforce1.42656567106328E12","display_name":"Andrew
+        Horner","email":"andrew@tablexi.com","email_verified":true,"first_name":"Andrew","last_name":"Horner","timezone":"America/Los_Angeles","photos":{"picture":"https://c.na24.content.force.com/profilephoto/005/F","thumbnail":"https://c.na24.content.force.com/profilephoto/005/T"},"addr_street":null,"addr_city":null,"addr_state":null,"addr_country":"US","addr_zip":"60661","mobile_phone":null,"mobile_phone_verified":false,"status":{"created_date":null,"body":null},"urls":{"enterprise":"https://<host>/services/Soap/c/{version}/00D1a000000H3O9","metadata":"https://<host>/services/Soap/m/{version}/00D1a000000H3O9","partner":"https://<host>/services/Soap/u/{version}/00D1a000000H3O9","rest":"https://<host>/services/data/v{version}/","sobjects":"https://<host>/services/data/v{version}/sobjects/","search":"https://<host>/services/data/v{version}/search/","query":"https://<host>/services/data/v{version}/query/","recent":"https://<host>/services/data/v{version}/recent/","profile":"https://<host>/0051a000000UGT8AAO","feeds":"https://<host>/services/data/v{version}/chatter/feeds","groups":"https://<host>/services/data/v{version}/chatter/groups","users":"https://<host>/services/data/v{version}/chatter/users","feed_items":"https://<host>/services/data/v{version}/chatter/feed-items"},"active":true,"user_type":"STANDARD","language":"en_US","locale":"en_US","utcOffset":-28800000,"last_modified_date":"2015-03-17T04:14:23.000+0000","is_app_installed":true}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:43 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -131,7 +207,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +218,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:20 GMT
+      - Mon, 08 Jun 2015 22:12:41 GMT
       Set-Cookie:
-      - BrowserId=26qDrJ9oRimWFj33h3Rn2g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:20 GMT
+      - BrowserId=t8pw5W7DRBqY5YErw536Og;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:41 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=580/15000
+      - api-usage=19/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -162,7 +238,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -171,12 +247,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:20 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:43 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5eAAE
     body:
       encoding: UTF-8
       string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
@@ -186,7 +262,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -197,22 +273,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:21 GMT
+      - Mon, 08 Jun 2015 22:12:42 GMT
       Set-Cookie:
-      - BrowserId=srKd43sFSk2YO8x9d8Y_4A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:21 GMT
+      - BrowserId=jp2mbijbSoeMJcfdzRsJbA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=583/15000
+      - api-usage=22/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:21 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:43 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCOAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5eAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +296,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -231,17 +307,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:22 GMT
+      - Mon, 08 Jun 2015 22:12:42 GMT
       Set-Cookie:
-      - BrowserId=v3lMTrFuRceX_kuGQW8urg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:22 GMT
+      - BrowserId=CWQjzybJShWgOi-VPT--YA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=580/15000
+      - api-usage=21/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:22 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:44 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/updates_the_salesforce_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:24 GMT
+      - Mon, 08 Jun 2015 22:12:42 GMT
       Set-Cookie:
-      - BrowserId=j2QgC7H7QJ2fAYEE43Pj0g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:24 GMT
+      - BrowserId=M0Xzc8kbSCqts3CZBxpIbw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1431652704097","token_type":"Bearer","instance_url":"https://<host>","signature":"nXpmcIeEZIsN2++65pm8yRR9GhzJ5rvZFWHa8lGdtaE=","access_token":"00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb"}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:24 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801562826","token_type":"Bearer","instance_url":"https://<host>","signature":"jiT+PIUIALZmAZwG0JOBevm1o4Hg4VLx62Zz6aqifN4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:44 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:25 GMT
+      - Mon, 08 Jun 2015 22:12:42 GMT
       Set-Cookie:
-      - BrowserId=06htfX4VR7OCduFgcqXWug;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:25 GMT
+      - BrowserId=DNgOmQfvQxe1OLlD_9Hwtw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:42 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=590/15000
+      - api-usage=26/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5jAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001ZoCTAA0","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:25 GMT
+      string: '{"id":"a001a000001cF5jAAE","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:44 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5jAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,24 +103,24 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:26 GMT
+      - Mon, 08 Jun 2015 22:12:43 GMT
       Set-Cookie:
-      - BrowserId=UoZgSeuFSmu8cr4-wpo_iw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:26 GMT
+      - BrowserId=F0enmizETNewdzUBNeRUKw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=587/15000
+      - api-usage=21/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:25.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5jAAE"},"Id":"a001a000001cF5jAAE","SystemModstamp":"2015-06-08T22:12:43.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:26 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:44 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:27 GMT
+      - Mon, 08 Jun 2015 22:12:43 GMT
       Set-Cookie:
-      - BrowserId=c9AkwNH6STubgb6B8OZILQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:27 GMT
+      - BrowserId=JHOiZmlnSGeArFmJmnEE5g;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=587/15000
+      - api-usage=23/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -162,7 +162,7 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NewsFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"UserProfileFeed","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false}],"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
         ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
         ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
         Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
@@ -171,12 +171,12 @@ http_interactions:
         Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
         Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
-    http_version:
-        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA"}],"replicateable":true,"retrieveable":true,"searchLayoutable":null,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","uiNewRecord":"https://<host>/a00/e"}}'
-  recorded_at: Fri, 15 May 2015 01:18:27 GMT
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:45 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5jAAE
     body:
       encoding: UTF-8
       string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
@@ -186,7 +186,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -197,22 +197,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:29 GMT
+      - Mon, 08 Jun 2015 22:12:43 GMT
       Set-Cookie:
-      - BrowserId=R3u76k9wSBGp4-fUj63zig;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:29 GMT
+      - BrowserId=siIYv-ZxS7iOmtLG0zsLNA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=588/15000
+      - api-usage=26/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:29 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:45 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001ZoCTAA0%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5jAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -220,7 +220,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -231,27 +231,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:30 GMT
+      - Mon, 08 Jun 2015 22:12:43 GMT
       Set-Cookie:
-      - BrowserId=s_oRgwrPSia56IwXQo01xQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:30 GMT
+      - BrowserId=a6YoXRKcTkOHtj95fPzgig;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:43 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=591/15000
+      - api-usage=23/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0"},"Id":"a001a000001ZoCTAA0","SystemModstamp":"2015-05-15T01:18:29.000+0000","Name":"Some
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5jAAE"},"Id":"a001a000001cF5jAAE","SystemModstamp":"2015-06-08T22:12:43.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Some
         new name","Example_Field__c":"New sample text"}]}'
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:30 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:45 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001ZoCTAA0
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5jAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -259,7 +259,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQOOuLg_qT_KH0d7e0MZl9eLqLOVkelXCvogl6uoC11zAr2MxSfN.Kp.FGeGl6RwwgcLORuGYbL2Rk2tznb5e22BOVEcb
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -270,17 +270,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 15 May 2015 01:18:32 GMT
+      - Mon, 08 Jun 2015 22:12:44 GMT
       Set-Cookie:
-      - BrowserId=rjBi2DCoSqSoM2K09UCWag;Path=/;Domain=.salesforce.com;Expires=Tue,
-        14-Jul-2015 01:18:32 GMT
+      - BrowserId=EequQt4LRae6qSPd7Tk2-w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=598/15000
+      - api-usage=25/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 15 May 2015 01:18:32 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:45 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:15 GMT
+      - Mon, 08 Jun 2015 22:13:30 GMT
       Set-Cookie:
-      - BrowserId=NaqbSOCqRUG6T6kMI7khkA;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:15 GMT
+      - BrowserId=6rksQ0W6QCuBzKF1oGhldg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433535915696","token_type":"Bearer","instance_url":"https://<host>","signature":"fD9CLmClrzCnCIA6HkADFMT5/dCPYKYImpoZjvAkDic=","access_token":"00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801610541","token_type":"Bearer","instance_url":"https://<host>","signature":"KXphh9VrM9/bno+EquLcW4Zp6oN/rKoNWPirsu9yZGU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:15 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:16 GMT
+      - Mon, 08 Jun 2015 22:13:30 GMT
       Set-Cookie:
-      - BrowserId=EYRZMT40RRiN-tBLEgOllw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:16 GMT
+      - BrowserId=0QpN7yMFTnm2KCoNM14GLg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=133/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF77AAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001c8ahAAA","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF77AAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:16 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8ahAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF77AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:17 GMT
+      - Mon, 08 Jun 2015 22:13:30 GMT
       Set-Cookie:
-      - BrowserId=xQtzOGa1SL-c96vfqFd1-Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:17 GMT
+      - BrowserId=z2JPoWC3TuebRgmpd0JXlQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:30 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=133/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"},"Id":"a001a000001c8ahAAA","SystemModstamp":"2015-06-05T20:25:16.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF77AAE"},"Id":"a001a000001cF77AAE","SystemModstamp":"2015-06-08T22:13:30.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:17 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8ahAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF77AAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:18 GMT
+      - Mon, 08 Jun 2015 22:13:31 GMT
       Set-Cookie:
-      - BrowserId=GV0SXgQCSqWGC-GW2kbr7Q;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:18 GMT
+      - BrowserId=TBGBZ8HVQTSfPWI5LBBCBg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=137/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA"},"Id":"a001a000001c8ahAAA","SystemModstamp":"2015-06-05T20:25:16.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF77AAE"},"Id":"a001a000001cF77AAE","SystemModstamp":"2015-06-08T22:13:30.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:18 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
 - request:
-    method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8ahAAA
+    method: get
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,62 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:13:31 GMT
+      Set-Cookie:
+      - BrowserId=CqLgPFijSImK51X-4hCcZA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=128/15000
+      Org.eclipse.jetty.server.include.etag:
+      - 7057c783
+      Last-Modified:
+      - Wed, 01 Apr 2015 17:47:03 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Etag:
+      - 7057c78-gzip"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"activateable":false,"childRelationships":[{"cascadeDelete":true,"childSObject":"AttachedContentDocument","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":"AttachedContentDocuments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Attachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Attachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CollaborationGroupRecord","deprecatedAndHidden":false,"field":"RecordId","relationshipName":"RecordAssociatedGroups","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CombinedAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"CombinedAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ContentDocumentLink","deprecatedAndHidden":false,"field":"LinkedEntityId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ContentVersion","deprecatedAndHidden":false,"field":"FirstPublishLocationId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"CustomObjectDetail__c","deprecatedAndHidden":false,"field":"CustomObject__c","relationshipName":"CustomObjectDetails__r","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"EntitySubscription","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"FeedSubscriptionsForEntity","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"FeedComment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"FeedItem","deprecatedAndHidden":false,"field":"ParentId","relationshipName":null,"restrictedDelete":false},{"cascadeDelete":true,"childSObject":"Note","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"Notes","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"NoteAndAttachment","deprecatedAndHidden":false,"field":"ParentId","relationshipName":"NotesAndAttachments","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"ProcessInstance","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessInstances","restrictedDelete":false},{"cascadeDelete":false,"childSObject":"ProcessInstanceHistory","deprecatedAndHidden":false,"field":"TargetObjectId","relationshipName":"ProcessSteps","restrictedDelete":false},{"cascadeDelete":true,"childSObject":"TopicAssignment","deprecatedAndHidden":false,"field":"EntityId","relationshipName":"TopicAssignments","restrictedDelete":false}],"compactLayoutable":true,"createable":true,"custom":true,"customSetting":false,"deletable":true,"deprecatedAndHidden":false,"feedEnabled":false,"fields":[{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"Record
+        ID","length":18,"name":"Id","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"id","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Owner
+        ID","length":18,"name":"OwnerId","nameField":false,"namePointing":true,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["Group","User"],"relationshipName":"Owner","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Deleted","length":0,"name":"IsDeleted","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":240,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":true,"inlineHelpText":null,"label":"CustomObject
+        Name","length":80,"name":"Name","nameField":true,"namePointing":false,"nillable":true,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
+        Date","length":0,"name":"CreatedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Created
+        By ID","length":18,"name":"CreatedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"CreatedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
+        Modified Date","length":0,"name":"LastModifiedDate","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Last
+        Modified By ID","length":18,"name":"LastModifiedById","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":["User"],"relationshipName":"LastModifiedBy","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":false,"custom":false,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":false,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"System
+        Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
+        Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
+- request:
+    method: patch
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF77AAE
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +236,51 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:19 GMT
+      - Mon, 08 Jun 2015 22:13:31 GMT
       Set-Cookie:
-      - BrowserId=i2ttnY_IShCGquR_RqSKug;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:19 GMT
+      - BrowserId=8mL4ziiaRryvjYQhfCAuTA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=134/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:19 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:32 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF77AAE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:13:31 GMT
+      Set-Cookie:
+      - BrowserId=yih7Dkz5SvWbHtTTInzFbw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:31 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=132/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:13:33 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_change_timestamp_is_stale/does_not_update_the_salesforce_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:20 GMT
+      - Mon, 08 Jun 2015 22:13:31 GMT
       Set-Cookie:
-      - BrowserId=Kty7tJAYT1qPGeq4D3Unug;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:20 GMT
+      - BrowserId=f-wz-bM2TY2PN3k32bWLhA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:31 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433535920475","token_type":"Bearer","instance_url":"https://<host>","signature":"O35nl1BtAs3tfVm7q9qvPHALERbq5y66/3Eo5ATxYCs=","access_token":"00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801611987","token_type":"Bearer","instance_url":"https://<host>","signature":"WnSJ6OkFGH0Y1xSh/Nuki4aHNZDN06l0RKIEfEpBA7w=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:20 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:33 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:21 GMT
+      - Mon, 08 Jun 2015 22:13:32 GMT
       Set-Cookie:
-      - BrowserId=LtnrKaJZSWGIynlqL75g8w;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:21 GMT
+      - BrowserId=DyZ-VAyLTJGydLyQGlwHHg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=139/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7zAAE"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001c8amAAA","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cF7zAAE","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:21 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:33 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7zAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:22 GMT
+      - Mon, 08 Jun 2015 22:13:32 GMT
       Set-Cookie:
-      - BrowserId=kXFjdyBMQqCtOcPfbobm0g;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:22 GMT
+      - BrowserId=zc3QhmX8SRi74_0UKvGIMw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=140/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7zAAE"},"Id":"a001a000001cF7zAAE","SystemModstamp":"2015-06-08T22:13:32.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:22 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:33 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7zAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:23 GMT
+      - Mon, 08 Jun 2015 22:13:32 GMT
       Set-Cookie:
-      - BrowserId=GOzB5Yp2RQOKO5AakuKbng;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:23 GMT
+      - BrowserId=4YX2w-ncQ325hcphVmzPeQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/15000
+      - api-usage=137/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7zAAE"},"Id":"a001a000001cF7zAAE","SystemModstamp":"2015-06-08T22:13:32.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:23 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:34 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001c8amAAA%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF7zAAE%27
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,27 +181,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:24 GMT
+      - Mon, 08 Jun 2015 22:13:32 GMT
       Set-Cookie:
-      - BrowserId=fpDWWW5iRZ26VWwJw39FPg;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:24 GMT
+      - BrowserId=qwxdAzJRR46S_pelRQO2Ww;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=135/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA"},"Id":"a001a000001c8amAAA","SystemModstamp":"2015-06-05T20:25:21.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7zAAE"},"Id":"a001a000001cF7zAAE","SystemModstamp":"2015-06-08T22:13:32.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:24 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:34 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001c8amAAA
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF7zAAE
     body:
       encoding: US-ASCII
       string: ''
@@ -209,7 +209,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQLdODWB6P_wMhlnykddo4HxmtCuVAVPgx9sgecmdoTNEs7010v3G1F8nbgWFQ_XozpNmW0nYAaVNlcbYhEEoEDBwHPmE
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -220,17 +220,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 05 Jun 2015 20:25:24 GMT
+      - Mon, 08 Jun 2015 22:13:32 GMT
       Set-Cookie:
-      - BrowserId=UXTZHmJ4Q7eeBuTTDakbOQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        04-Aug-2015 20:25:24 GMT
+      - BrowserId=gZwLvDnwSz-IHURJyzIt5w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:13:32 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=5/15000
+      - api-usage=134/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 05 Jun 2015 20:25:25 GMT
+  recorded_at: Mon, 08 Jun 2015 22:13:34 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_changes_are_current/updates_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_changes_are_current/updates_the_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:07 GMT
+      - Mon, 08 Jun 2015 22:42:49 GMT
       Set-Cookie:
-      - BrowserId=HTTFWFu3QNqv9izGIEXZOQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:07 GMT
+      - BrowserId=6rY8mrerS6-JN1_nj6CeAQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,57 +37,15 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801587122","token_type":"Bearer","instance_url":"https://<host>","signature":"S7xaagp0TWcAwoMAJaxNDmNvj2nWbkZRablpSEZuQCM=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433803369521","token_type":"Bearer","instance_url":"https://<host>","signature":"lOKY428KQG378aa2l6fTibL3rSVcBTivD1b4PvSpkE8=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:08 GMT
-- request:
-    method: post
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact
-    body:
-      encoding: UTF-8
-      string: '{"Email":"somebody@example.com","LastName":"Somebody"}'
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:07 GMT
-      Set-Cookie:
-      - BrowserId=QzeOvpjcT2OorA7HjT2rpg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:07 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=53/15000
-      Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNNAAY"
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"0031a000004cfNNAAY","success":true,"errors":[]}'
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:08 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:51 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000004cfNNAAY"}'
+      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -105,70 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:07 GMT
+      - Mon, 08 Jun 2015 22:42:49 GMT
       Set-Cookie:
-      - BrowserId=ku0REZqmSOWOqHK3SwOMmA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:07 GMT
+      - BrowserId=Ees122JNQei5LnVGVPG7Rg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=51/15000
+      - api-usage=315/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoOAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001cF6wAAE","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cFoOAAU","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:09 GMT
-- request:
-    method: post
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact
-    body:
-      encoding: UTF-8
-      string: '{"Email":"somebody+else@example.com","LastName":"Somebody"}'
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Content-Type:
-      - application/json
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:07 GMT
-      Set-Cookie:
-      - BrowserId=idpJ_z_UTSSCEbkzeekDPg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:07 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=60/15000
-      Location:
-      - "/services/data/<api_version>/sobjects/Contact/0031a000004cfNSAAY"
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"id":"0031a000004cfNSAAY","success":true,"errors":[]}'
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:09 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:51 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cFoOAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -187,23 +103,100 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:07 GMT
+      - Mon, 08 Jun 2015 22:42:49 GMT
       Set-Cookie:
-      - BrowserId=tgaku49mTPOynEqcmgYnSA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:07 GMT
+      - BrowserId=EO6NwEF5QyKTiMdygqaH2A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=56/15000
+      - api-usage=315/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null,"Friend__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE"},"Id":"a001a000001cF6wAAE","SystemModstamp":"2015-06-08T22:13:07.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF6w","Example_Field__c":null,"Friend__c":"0031a000004cfNNAAY"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoOAAU"},"Id":"a001a000001cFoOAAU","SystemModstamp":"2015-06-08T22:42:49.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:09 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:51 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:42:50 GMT
+      Set-Cookie:
+      - BrowserId=GuLQ9f7GQsS1-A5qh_O-Ag;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:50 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=315/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"limits":"/services/data/<api_version>/limits","sobjects":"/services/data/<api_version>/sobjects","connect":"/services/data/<api_version>/connect","query":"/services/data/<api_version>/query","theme":"/services/data/<api_version>/theme","queryAll":"/services/data/<api_version>/queryAll","tooling":"/services/data/<api_version>/tooling","chatter":"/services/data/<api_version>/chatter","analytics":"/services/data/<api_version>/analytics","recent":"/services/data/<api_version>/recent","commerce":"/services/data/<api_version>/commerce","licensing":"/services/data/<api_version>/licensing","identity":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","flexiPage":"/services/data/<api_version>/flexiPage","search":"/services/data/<api_version>/search","quickActions":"/services/data/<api_version>/quickActions","appMenu":"/services/data/<api_version>/appMenu"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:42:51 GMT
+- request:
+    method: get
+    uri: https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:42:50 GMT
+      - Mon, 08 Jun 2015 22:42:50 GMT
+      Set-Cookie:
+      - BrowserId=U1dzvm5HRu6mCZb2QVYAWw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:50 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","asserted_user":true,"user_id":"0051a000000UGT8AAO","organization_id":"00D1a000000H3O9EAK","username":"andrew+salesforce@tablexi.com","nick_name":"andrew+salesforce1.42656567106328E12","display_name":"Andrew
+        Horner","email":"andrew@tablexi.com","email_verified":true,"first_name":"Andrew","last_name":"Horner","timezone":"America/Los_Angeles","photos":{"picture":"https://c.na24.content.force.com/profilephoto/005/F","thumbnail":"https://c.na24.content.force.com/profilephoto/005/T"},"addr_street":null,"addr_city":null,"addr_state":null,"addr_country":"US","addr_zip":"60661","mobile_phone":null,"mobile_phone_verified":false,"status":{"created_date":null,"body":null},"urls":{"enterprise":"https://<host>/services/Soap/c/{version}/00D1a000000H3O9","metadata":"https://<host>/services/Soap/m/{version}/00D1a000000H3O9","partner":"https://<host>/services/Soap/u/{version}/00D1a000000H3O9","rest":"https://<host>/services/data/v{version}/","sobjects":"https://<host>/services/data/v{version}/sobjects/","search":"https://<host>/services/data/v{version}/search/","query":"https://<host>/services/data/v{version}/query/","recent":"https://<host>/services/data/v{version}/recent/","profile":"https://<host>/0051a000000UGT8AAO","feeds":"https://<host>/services/data/v{version}/chatter/feeds","groups":"https://<host>/services/data/v{version}/chatter/groups","users":"https://<host>/services/data/v{version}/chatter/users","feed_items":"https://<host>/services/data/v{version}/chatter/feed-items"},"active":true,"user_type":"STANDARD","language":"en_US","locale":"en_US","utcOffset":-28800000,"last_modified_date":"2015-03-17T04:14:23.000+0000","is_app_installed":true}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:42:52 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -225,14 +218,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:08 GMT
+      - Mon, 08 Jun 2015 22:42:50 GMT
       Set-Cookie:
-      - BrowserId=_nhj_IeAQ9O67Cdiy_0ZTQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:08 GMT
+      - BrowserId=EJI_4BcjRR2V7jigrXonaw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=50/15000
+      - api-usage=316/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -256,13 +249,13 @@ http_interactions:
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
         Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:09 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:52 GMT
 - request:
     method: patch
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoOAAU
     body:
       encoding: UTF-8
-      string: '{"Friend__c":"0031a000004cfNSAAY"}'
+      string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -280,98 +273,22 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:08 GMT
+      - Mon, 08 Jun 2015 22:42:50 GMT
       Set-Cookie:
-      - BrowserId=PUVIlpRHSIeKFjkxe4SeLw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:08 GMT
+      - BrowserId=GXI1Zx11RkigCErfvQvnkA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:50 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=56/15000
+      - api-usage=315/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:09 GMT
-- request:
-    method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6wAAE%27
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:08 GMT
-      Set-Cookie:
-      - BrowserId=WoWrTUxuTk2y6nXxhyTNxQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:08 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=57/15000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE"},"Id":"a001a000001cF6wAAE","SystemModstamp":"2015-06-08T22:13:08.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF6w","Example_Field__c":null,"Friend__c":"0031a000004cfNSAAY"}]}'
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:10 GMT
-- request:
-    method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c,%20Friend__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF6wAAE%27
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:08 GMT
-      Set-Cookie:
-      - BrowserId=Oj8Rxq44Q-K-Q_ApzYYaVA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:08 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=54/15000
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE"},"Id":"a001a000001cF6wAAE","SystemModstamp":"2015-06-08T22:13:08.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"a001a000001cF6w","Example_Field__c":null,"Friend__c":"0031a000004cfNSAAY"}]}'
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:10 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:52 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNNAAY
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoOAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -390,85 +307,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:13:08 GMT
+      - Mon, 08 Jun 2015 22:42:51 GMT
       Set-Cookie:
-      - BrowserId=gmdGO5ujQ9SMVlX0inMsGw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:08 GMT
+      - BrowserId=OCF9y3rbQyeDeyJ55FDv3w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=60/15000
+      - api-usage=315/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:10 GMT
-- request:
-    method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF6wAAE
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:09 GMT
-      Set-Cookie:
-      - BrowserId=f3opiVn6TLCSiBep8Uoc1g;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:09 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=63/15000
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:10 GMT
-- request:
-    method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/Contact/0031a000004cfNSAAY
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v0.9.1
-      Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Date:
-      - Mon, 08 Jun 2015 22:13:09 GMT
-      Set-Cookie:
-      - BrowserId=24E8FeCtTkOdVzSUlbiRJw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:13:09 GMT
-      Expires:
-      - Thu, 01 Jan 1970 00:00:00 GMT
-      Sforce-Limit-Info:
-      - api-usage=56/15000
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:13:11 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:52 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_changes_are_current/updates_the_salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_an_associated_database_record/when_the_changes_are_current/updates_the_salesforce_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:13 GMT
+      - Mon, 08 Jun 2015 22:42:51 GMT
       Set-Cookie:
-      - BrowserId=JaXehgZ1SM225bOJzVZTHg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:13 GMT
+      - BrowserId=iSnrTfFsS_iYv-2EY4TKnQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,90 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801533352","token_type":"Bearer","instance_url":"https://<host>","signature":"AUiJO49nQrTftOCAJqm+IxADnymEqTnLVG5WKgPAtEI=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433803371519","token_type":"Bearer","instance_url":"https://<host>","signature":"9PtVYLeiEUB7sjOujiGfMl+Hs2C7n/NS5R3QTqlHkc4=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:14 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:53 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:42:51 GMT
+      Set-Cookie:
+      - BrowserId=7dYwV-Z7QsCzGabZnWz_bQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:51 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=316/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoTAAU"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001cFoTAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:42:53 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cFoTAAU%27
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Jun 2015 22:42:51 GMT
+      Set-Cookie:
+      - BrowserId=O5ztTGhqREqoY4WvmNO0aQ;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:51 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=315/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoTAAU"},"Id":"a001a000001cFoTAAU","SystemModstamp":"2015-06-08T22:42:51.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:42:53 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/describe
@@ -61,14 +142,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:13 GMT
+      - Mon, 08 Jun 2015 22:42:52 GMT
       Set-Cookie:
-      - BrowserId=nu379x0ARv-1QT66MuLXXg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:13 GMT
+      - BrowserId=qv7ABCdLQBmLqy2oNVnBEg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/15000
+      - api-usage=316/15000
       Org.eclipse.jetty.server.include.etag:
       - 7057c783
       Last-Modified:
@@ -92,13 +173,13 @@ http_interactions:
         Modstamp","length":0,"name":"SystemModstamp","nameField":false,"namePointing":false,"nillable":false,"permissionable":false,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:dateTime","sortable":true,"type":"datetime","unique":false,"updateable":false,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":765,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Example
         Field","length":255,"name":"Example_Field__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:string","sortable":true,"type":"string","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":18,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":false,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Friend","length":18,"name":"Friend__c","nameField":false,"namePointing":false,"nillable":true,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":["Contact"],"relationshipName":"Friend__r","relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"tns:ID","sortable":true,"type":"reference","unique":false,"updateable":true,"writeRequiresMasterRead":false},{"autoNumber":false,"byteLength":0,"calculated":false,"calculatedFormula":null,"cascadeDelete":false,"caseSensitive":false,"controllerName":null,"createable":true,"custom":true,"defaultValue":null,"defaultValueFormula":null,"defaultedOnCreate":true,"dependentPicklist":false,"deprecatedAndHidden":false,"digits":0,"displayLocationInDecimal":false,"externalId":false,"filterable":true,"groupable":true,"htmlFormatted":false,"idLookup":false,"inlineHelpText":null,"label":"Visible","length":0,"name":"Visible__c","nameField":false,"namePointing":false,"nillable":false,"permissionable":true,"picklistValues":[],"precision":0,"referenceTo":[],"relationshipName":null,"relationshipOrder":null,"restrictedDelete":false,"restrictedPicklist":false,"scale":0,"soapType":"xsd:boolean","sortable":true,"type":"boolean","unique":false,"updateable":true,"writeRequiresMasterRead":false}],"keyPrefix":"a00","label":"CustomObject","labelPlural":"CustomObjects","layoutable":true,"listviewable":null,"lookupLayoutable":null,"mergeable":false,"name":"CustomObject__c","queryable":true,"recordTypeInfos":[{"available":true,"defaultRecordTypeMapping":true,"name":"Master","recordTypeId":"012000000000000AAA","urls":{"layout":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts/012000000000000AAA"}}],"replicateable":true,"retrieveable":true,"searchLayoutable":true,"searchable":true,"triggerable":true,"undeletable":true,"updateable":true,"urls":{"uiEditTemplate":"https://<host>/{ID}/e","sobject":"/services/data/<api_version>/sobjects/CustomObject__c","quickActions":"/services/data/<api_version>/sobjects/CustomObject__c/quickActions","uiDetailTemplate":"https://<host>/{ID}","describe":"/services/data/<api_version>/sobjects/CustomObject__c/describe","rowTemplate":"/services/data/<api_version>/sobjects/CustomObject__c/{ID}","layouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/layouts","compactLayouts":"/services/data/<api_version>/sobjects/CustomObject__c/describe/compactLayouts","uiNewRecord":"https://<host>/a00/e"}}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:15 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:53 GMT
 - request:
-    method: post
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    method: patch
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoTAAU
     body:
       encoding: UTF-8
-      string: '{"Name":"Something","Example_Field__c":"Something else"}'
+      string: '{"Name":"Some new name","Example_Field__c":"New sample text"}'
     headers:
       User-Agent:
       - Faraday v0.9.1
@@ -112,32 +193,26 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 201
-      message: Created
+      code: 204
+      message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:13 GMT
+      - Mon, 08 Jun 2015 22:42:52 GMT
       Set-Cookie:
-      - BrowserId=80U-WGB1Q4-kd8e8mWo8Sg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:13 GMT
+      - BrowserId=z1zczRTBQbyWffgRowSvKA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=6/15000
-      Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF47AAE"
-      Content-Type:
-      - application/json;charset=UTF-8
-      Transfer-Encoding:
-      - chunked
+      - api-usage=315/15000
     body:
-      encoding: ASCII-8BIT
-      string: '{"id":"a001a000001cF47AAE","success":true,"errors":[]}'
+      encoding: UTF-8
+      string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:15 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:53 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF47AAE%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cFoTAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -156,27 +231,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:14 GMT
+      - Mon, 08 Jun 2015 22:42:52 GMT
       Set-Cookie:
-      - BrowserId=KUdPxRWdRkSV8CNDrNHJng;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:14 GMT
+      - BrowserId=inhP3vErToS89ZKvIAKA8w;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=7/15000
+      - api-usage=315/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF47AAE"},"Id":"a001a000001cF47AAE","SystemModstamp":"2015-06-08T22:12:13.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Something","Example_Field__c":"Something
-        else"}]}'
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoTAAU"},"Id":"a001a000001cFoTAAU","SystemModstamp":"2015-06-08T22:42:52.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Some
+        new name","Example_Field__c":"New sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:15 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:54 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF47AAE
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cFoTAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -195,17 +270,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:14 GMT
+      - Mon, 08 Jun 2015 22:42:52 GMT
       Set-Cookie:
-      - BrowserId=WegF3yJtQwKaNGnBGwwTFw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:14 GMT
+      - BrowserId=-myIAmnaRcSL5fxa59Twvw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:42:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=8/15000
+      - api-usage=317/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:15 GMT
+  recorded_at: Mon, 08 Jun 2015 22:42:54 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_no_associated_database_record/does_nothing_for_this_specific_mapping.yml
+++ b/test/cassettes/Restforce_DB_Synchronizer/_run/given_a_Salesforce_record_with_no_associated_database_record/does_nothing_for_this_specific_mapping.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 18:16:05 GMT
+      - Mon, 08 Jun 2015 22:12:19 GMT
       Set-Cookie:
-      - BrowserId=pcw4QakVSumA7tABeMs79A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 18:16:05 GMT
+      - BrowserId=bfcKIwigRaCCAUYsRqbrJA;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1428689765521","token_type":"Bearer","instance_url":"https://<host>","signature":"iVn8K79ySw/26GQM8/ZHlQ7tE1l2EUH+WGphHVWkQFg=","access_token":"00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ"}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801539774","token_type":"Bearer","instance_url":"https://<host>","signature":"zuuyrTiCjqR3OlEVII57V+9sykZ8S2+APFACft4wui0=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:21 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 10 Apr 2015 18:16:05 GMT
+      - Mon, 08 Jun 2015 22:12:19 GMT
       Set-Cookie:
-      - BrowserId=I0vlITthQ-GdMURdX_Eu4A;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 18:16:05 GMT
+      - BrowserId=6Wf1sZNMQxO8NW99U3oF3A;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:19 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=58/15000
+      - api-usage=6/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4WAAU"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001LXBfAAO","success":true,"errors":[]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
+      string: '{"id":"a001a000001cF4WAAU","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4WAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,27 +103,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 18:16:05 GMT
+      - Mon, 08 Jun 2015 22:12:20 GMT
       Set-Cookie:
-      - BrowserId=KoiOz0-gSYiQzd8NJ4uMRQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 18:16:05 GMT
+      - BrowserId=ZUuh75WBTc2uJK9qLmI_Jw;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=58/15000
+      - api-usage=8/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4WAAU"},"Id":"a001a000001cF4WAAU","SystemModstamp":"2015-06-08T22:12:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 18:16:05 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:21 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001LXBfAAO%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4WAAU%27
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 10 Apr 2015 18:16:06 GMT
+      - Mon, 08 Jun 2015 22:12:20 GMT
       Set-Cookie:
-      - BrowserId=GS8k_s93SVmx-JpXvfVjPQ;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 18:16:06 GMT
+      - BrowserId=vCkQaDr4SOG6fPNGhW82Ew;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=58/15000
+      - api-usage=6/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO"},"Id":"a001a000001LXBfAAO","SystemModstamp":"2015-04-10T18:16:05.000+0000","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4WAAU"},"Id":"a001a000001cF4WAAU","SystemModstamp":"2015-06-08T22:12:19.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 18:16:06 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:21 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001LXBfAAO
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4WAAU
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQO48p7VCPJTqs85KtBx3kEBjPhP.lCvkGK3ayiFCcg2H2nbFwdKZaBetwWzVAndOSywkSvoT7_YZEmwLnhtbJ1A3E5NZ
+      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +181,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 10 Apr 2015 18:16:09 GMT
+      - Mon, 08 Jun 2015 22:12:20 GMT
       Set-Cookie:
-      - BrowserId=KJPi4MJTQ0mr8dA2ahBjEw;Path=/;Domain=.salesforce.com;Expires=Tue,
-        09-Jun-2015 18:16:09 GMT
+      - BrowserId=mRxeH9KIQomK7xd4NS4Zjg;Path=/;Domain=.salesforce.com;Expires=Fri,
+        07-Aug-2015 22:12:20 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=58/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
-    http_version:
-  recorded_at: Fri, 10 Apr 2015 18:16:09 GMT
+    http_version: 
+  recorded_at: Mon, 08 Jun 2015 22:12:22 GMT
 recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/instances/active_record_test.rb
+++ b/test/lib/restforce/db/instances/active_record_test.rb
@@ -29,4 +29,27 @@ describe Restforce::DB::Instances::ActiveRecord do
       expect(record.reload.synchronized_at).to_not_be_nil
     end
   end
+
+  describe "#updated_internally?" do
+
+    describe "when updated_at exceeds synchronized_at" do
+      before do
+        record.update!(synchronized_at: Time.now - 2)
+      end
+
+      it "returns false" do
+        expect(instance).to_not_be :updated_internally?
+      end
+    end
+
+    describe "when synchronized_at meets or exceeds updated_at" do
+      before do
+        record.touch(:synchronized_at)
+      end
+
+      it "returns true" do
+        expect(instance).to_be :updated_internally?
+      end
+    end
+  end
 end

--- a/test/lib/restforce/db/instances/salesforce_test.rb
+++ b/test/lib/restforce/db/instances/salesforce_test.rb
@@ -54,4 +54,24 @@ describe Restforce::DB::Instances::Salesforce do
     end
   end
 
+  describe "#updated_internally?", :vcr do
+
+    describe "when our client made the last change" do
+
+      it "returns true" do
+        expect(instance).to_be :updated_internally?
+      end
+    end
+
+    describe "when another user made the last change" do
+      let(:user_id) { "a001a000001E1vFAKE" }
+      let(:record) { Struct.new(:LastModifiedById).new(user_id) }
+      let(:instance) { Restforce::DB::Instances::Salesforce.new(salesforce_model, record) }
+
+      it "returns false" do
+        expect(instance).to_not_be :updated_internally?
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Our current approach to preventing synchronization race conditions is
a little bit too strict, in that it doesn't allow the Restforce::DB worker to
synchronize multiple changesets onto one record as part of a single
synchronization loop -- it identifies queued-up changes as "stale" after 
the first set is applied, and discards the remaining changes for subsequent
mappings.

In order to identify changes to Salesforce records made outside of the
Restforce::DB system, we need to pull down the ID of the user for which
the client is currently authorized, and compare it to the user who
last modified the record. This means pulling down the LastModifiedById,
which means rebuilding all of our cassettes, but sacrifices have to be
made sometimes.

Now that we can check for internal vs. external record updates, we can
wire that logic into our Synchronizer when determining whether or not
we should prevent the sync based on “stale” data.