### PR TITLE
Disregard record changes known to Restforce::DB’s worker

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -32,6 +32,7 @@ require "restforce/db/strategies/associated"
 require "restforce/db/strategies/passive"
 
 require "restforce/db/record_cache"
+require "restforce/db/timestamp_cache"
 require "restforce/db/runner"
 
 require "restforce/db/accumulator"

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -31,7 +31,7 @@ require "restforce/db/strategies/always"
 require "restforce/db/strategies/associated"
 require "restforce/db/strategies/passive"
 
-require "restforce/db/runner_cache"
+require "restforce/db/record_cache"
 require "restforce/db/runner"
 
 require "restforce/db/accumulator"

--- a/lib/restforce/db/collector.rb
+++ b/lib/restforce/db/collector.rb
@@ -54,6 +54,8 @@ module Restforce
       #
       # Returns nothing.
       def accumulate(instance)
+        return unless @runner.changed?(instance)
+
         accumulated_changes[key_for(instance)].store(
           instance.last_update,
           instance.attributes,

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -42,7 +42,7 @@ module Restforce
       def create_in_database(instance)
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
-        @runner.update instance
+        @runner.cache_timestamp instance
       rescue ActiveRecord::ActiveRecordError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end
@@ -57,7 +57,7 @@ module Restforce
       def create_in_salesforce(instance)
         return if instance.synced?
         @mapping.salesforce_record_type.create!(instance)
-        @runner.update instance
+        @runner.cache_timestamp instance
       rescue Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -42,6 +42,7 @@ module Restforce
       def create_in_database(instance)
         return unless @strategy.build?(instance)
         @mapping.database_record_type.create!(instance)
+        @runner.update instance
       rescue ActiveRecord::ActiveRecordError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end
@@ -56,6 +57,7 @@ module Restforce
       def create_in_salesforce(instance)
         return if instance.synced?
         @mapping.salesforce_record_type.create!(instance)
+        @runner.update instance
       rescue Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end

--- a/lib/restforce/db/record_cache.rb
+++ b/lib/restforce/db/record_cache.rb
@@ -2,14 +2,14 @@ module Restforce
 
   module DB
 
-    # Restforce::DB::RunnerCache serves as a means of caching the collections of
+    # Restforce::DB::RecordCache serves as a means of caching the collections of
     # recently-updated database and Salesforce instances for passed mappings.
     # The general goal is to avoid making repetitive Salesforce API calls or
     # database queries, and ensure a consistent list of objects during a
     # synchronization run.
-    class RunnerCache
+    class RecordCache
 
-      # Public: Initialize a new Restforce::DB::RunnerCache.
+      # Public: Initialize a new Restforce::DB::RecordCache.
       def initialize
         reset
       end

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -13,7 +13,7 @@ module Restforce
       extend Forwardable
       def_delegators(
         :@timestamp_cache,
-        :update,
+        :cache_timestamp,
         :changed?,
       )
 

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -19,7 +19,7 @@ module Restforce
       def initialize(delay = 0, last_run_time = DB.last_run)
         @delay = delay
         @last_run = last_run_time
-        @cache = RunnerCache.new
+        @record_cache = RecordCache.new
       end
 
       # Public: Indicate that a new phase of the run is beginning. Updates the
@@ -27,7 +27,7 @@ module Restforce
       #
       # Returns the new run Time.
       def tick!
-        @cache.reset
+        @record_cache.reset
         run_time = Time.now
 
         @before = run_time - @delay
@@ -54,7 +54,7 @@ module Restforce
       #
       # Returns an Enumerator yielding Restforce::DB::Instances::Salesforces.
       def salesforce_instances
-        @cache.collection(@mapping, :salesforce_record_type, options)
+        @record_cache.collection(@mapping, :salesforce_record_type, options)
       end
 
       # Public: Iterate through recently-updated records for the database model
@@ -62,7 +62,7 @@ module Restforce
       #
       # Returns an Enumerator yielding Restforce::DB::Instances::ActiveRecords.
       def database_instances
-        @cache.collection(@mapping, :database_record_type, options)
+        @record_cache.collection(@mapping, :database_record_type, options)
       end
 
       private

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -10,6 +10,13 @@ module Restforce
       attr_reader :last_run
       attr_accessor :before, :after
 
+      extend Forwardable
+      def_delegators(
+        :@timestamp_cache,
+        :update,
+        :changed?,
+      )
+
       # Public: Initialize a new Restforce::DB::Runner.
       #
       # delay         - A Numeric offet to apply to all record lookups. Can be
@@ -20,6 +27,7 @@ module Restforce
         @delay = delay
         @last_run = last_run_time
         @record_cache = RecordCache.new
+        @timestamp_cache = TimestampCache.new
       end
 
       # Public: Indicate that a new phase of the run is beginning. Updates the
@@ -28,6 +36,8 @@ module Restforce
       # Returns the new run Time.
       def tick!
         @record_cache.reset
+        @timestamp_cache.reset
+
         run_time = Time.now
 
         @before = run_time - @delay

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -68,7 +68,7 @@ module Restforce
         attributes = @mapping.convert(instance.record_type, current_attributes)
 
         instance.update!(attributes)
-        @runner.update instance
+        @runner.cache_timestamp instance
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end

--- a/lib/restforce/db/synchronizer.rb
+++ b/lib/restforce/db/synchronizer.rb
@@ -11,8 +11,9 @@ module Restforce
       # Public: Initialize a new Restforce::DB::Synchronizer.
       #
       # mapping - A Restforce::DB::Mapping.
-      def initialize(mapping)
+      def initialize(mapping, runner = Runner.new)
         @mapping = mapping
+        @runner = runner
       end
 
       # Public: Synchronize records for the current mapping from a Hash of
@@ -67,6 +68,7 @@ module Restforce
         attributes = @mapping.convert(instance.record_type, current_attributes)
 
         instance.update!(attributes)
+        @runner.update instance
       rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end

--- a/lib/restforce/db/timestamp_cache.rb
+++ b/lib/restforce/db/timestamp_cache.rb
@@ -1,0 +1,76 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::TimestampCache serves to cache the timestamps of the most
+    # recent known updates to records through the Restforce::DB system. It
+    # allows for more intelligent decision-making regarding what constitutes
+    # "stale" data during a synchronization.
+    class TimestampCache
+
+      # Public: Initialize a new Restforce::DB::TimestampCache.
+      def initialize
+        reset
+      end
+
+      # Public: Add a known update timestamp to the cache for the passed object.
+      #
+      # instance - A Restforce::DB::Instances::Base.
+      #
+      # Returns an Array of Restforce::DB::Instances::Base.
+      def update(instance)
+        @cache[key_for(instance)] = instance.last_update
+      end
+
+      # Public: Get the most recently-stored timestamp for the passed object.
+      #
+      # instance - A Restforce::DB::Instances::Base.
+      #
+      # Returns a Time or nil.
+      def timestamp(instance)
+        key = key_for(instance)
+        @cache.fetch(key) { @last_cache[key] }
+      end
+
+      # Public: Has the passed instance been modified since the last known
+      # system-triggered update? This accounts for changes possibly introduced
+      # by callbacks and triggers.
+      #
+      # instance - A Restforce::DB::Instances::Base.
+      #
+      # Returns a Boolean.
+      def changed?(instance)
+        return true unless instance.updated_internally?
+
+        last_update = timestamp(instance)
+        return true unless last_update
+
+        instance.last_update > last_update
+      end
+
+      # Public: Reset the cache. Expires the previously-cached timestamps, and
+      # retires the currently-cached timestamps to ensure that they are only
+      # factored into the current synchronization run.
+      #
+      # Returns nothing.
+      def reset
+        @last_cache = @cache || {}
+        @cache = {}
+      end
+
+      private
+
+      # Internal: Get a unique cache key for the passed instance.
+      #
+      # instance - A Restforce::DB::Instances::Base.
+      #
+      # Returns an Object.
+      def key_for(instance)
+        [instance.class, instance.id]
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/extensions.rb
+++ b/lib/restforce/extensions.rb
@@ -10,8 +10,11 @@ module Restforce
     # Raises on update error.
     def update!(attributes)
       ensure_id
-      @client.update!(sobject_type, attributes.merge("Id" => self.Id))
+      response = @client.api_patch("sobjects/#{sobject_type}/#{self.Id}", attributes)
+      update_time = response.env.response_headers["date"]
+
       merge!(attributes)
+      merge!("SystemModstamp" => update_time)
     end
 
   end

--- a/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_a_Salesforce_record_with_an_associated_database_record/returns_the_attributes_from_both_records.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:26 GMT
+      - Wed, 10 Jun 2015 20:32:44 GMT
       Set-Cookie:
-      - BrowserId=IUZDct2tRqSbtEnKBAjLkA;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:26 GMT
+      - BrowserId=9Hgb4W9BTOiz0oOQfDpBJQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:44 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801546572","token_type":"Bearer","instance_url":"https://<host>","signature":"eWPqcCY6D2iKBFJv8pRBafWGp81i1uiYtMQhH3ams1A=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433968364523","token_type":"Bearer","instance_url":"https://<host>","signature":"zcpougnZQ2racBXMLaAcuvkzZwe1/RR0A8tzoGprA3A=","access_token":"00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:44 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:26 GMT
+      - Wed, 10 Jun 2015 20:32:45 GMT
       Set-Cookie:
-      - BrowserId=2hj5KwxMTnyS57eKQkeL-A;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:26 GMT
+      - BrowserId=6Kjpln3uTfWvUxegpDoqzg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:45 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/15000
+      - api-usage=26/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNTxAAM"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001cF4vAAE","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cNTxAAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:45 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF4vAAE%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cNTxAAM%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,24 +103,24 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:26 GMT
+      - Wed, 10 Jun 2015 20:32:46 GMT
       Set-Cookie:
-      - BrowserId=_JZ2ryP4TlOZ6qkKrYZrkw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:26 GMT
+      - BrowserId=C41i4AOPQL2EQtrWf-LKkQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:46 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=8/15000
+      - api-usage=26/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"},"Id":"a001a000001cF4vAAE","SystemModstamp":"2015-06-08T22:12:26.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNTxAAM"},"Id":"a001a000001cNTxAAM","SystemModstamp":"2015-06-10T20:32:45.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:46 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:27 GMT
+      - Wed, 10 Jun 2015 20:32:47 GMT
       Set-Cookie:
-      - BrowserId=4BMkj87_RF2aLa2fDpaD5Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:27 GMT
+      - BrowserId=xpCMtB2bSyaAx3uzaOnq1A;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:47 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=8/15000
+      - api-usage=26/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE"},"Id":"a001a000001cF4vAAE","SystemModstamp":"2015-06-08T22:12:26.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNTxAAM"},"Id":"a001a000001cNTxAAM","SystemModstamp":"2015-06-10T20:32:45.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:47 GMT
 - request:
-    method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF4vAAE
+    method: get
+    uri: https://<host>/services/data/<api_version>/
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,83 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:32:48 GMT
+      Set-Cookie:
+      - BrowserId=QD5WY6z2Qiq-7x6swz6Uhg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=26/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"limits":"/services/data/<api_version>/limits","sobjects":"/services/data/<api_version>/sobjects","connect":"/services/data/<api_version>/connect","query":"/services/data/<api_version>/query","theme":"/services/data/<api_version>/theme","queryAll":"/services/data/<api_version>/queryAll","tooling":"/services/data/<api_version>/tooling","chatter":"/services/data/<api_version>/chatter","analytics":"/services/data/<api_version>/analytics","recent":"/services/data/<api_version>/recent","commerce":"/services/data/<api_version>/commerce","licensing":"/services/data/<api_version>/licensing","identity":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","flexiPage":"/services/data/<api_version>/flexiPage","search":"/services/data/<api_version>/search","quickActions":"/services/data/<api_version>/quickActions","appMenu":"/services/data/<api_version>/appMenu"}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:32:48 GMT
+- request:
+    method: get
+    uri: https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:32:48 GMT
+      - Wed, 10 Jun 2015 20:32:48 GMT
+      Set-Cookie:
+      - BrowserId=rzInOdn_Sj-cfQNluztySw;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:48 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","asserted_user":true,"user_id":"0051a000000UGT8AAO","organization_id":"00D1a000000H3O9EAK","username":"andrew+salesforce@tablexi.com","nick_name":"andrew+salesforce1.42656567106328E12","display_name":"Andrew
+        Horner","email":"andrew@tablexi.com","email_verified":true,"first_name":"Andrew","last_name":"Horner","timezone":"America/Los_Angeles","photos":{"picture":"https://c.na24.content.force.com/profilephoto/005/F","thumbnail":"https://c.na24.content.force.com/profilephoto/005/T"},"addr_street":null,"addr_city":null,"addr_state":null,"addr_country":"US","addr_zip":"60661","mobile_phone":null,"mobile_phone_verified":false,"status":{"created_date":null,"body":null},"urls":{"enterprise":"https://<host>/services/Soap/c/{version}/00D1a000000H3O9","metadata":"https://<host>/services/Soap/m/{version}/00D1a000000H3O9","partner":"https://<host>/services/Soap/u/{version}/00D1a000000H3O9","rest":"https://<host>/services/data/v{version}/","sobjects":"https://<host>/services/data/v{version}/sobjects/","search":"https://<host>/services/data/v{version}/search/","query":"https://<host>/services/data/v{version}/query/","recent":"https://<host>/services/data/v{version}/recent/","profile":"https://<host>/0051a000000UGT8AAO","feeds":"https://<host>/services/data/v{version}/chatter/feeds","groups":"https://<host>/services/data/v{version}/chatter/groups","users":"https://<host>/services/data/v{version}/chatter/users","feed_items":"https://<host>/services/data/v{version}/chatter/feed-items"},"active":true,"user_type":"STANDARD","language":"en_US","locale":"en_US","utcOffset":-28800000,"last_modified_date":"2015-03-17T04:14:23.000+0000","is_app_installed":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:32:48 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNTxAAM
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +257,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:27 GMT
+      - Wed, 10 Jun 2015 20:32:49 GMT
       Set-Cookie:
-      - BrowserId=cRMxZ9gSSN2YVrMFxyeCEw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:27 GMT
+      - BrowserId=-imEDwZ0TCanwP026i4teQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:49 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=9/15000
+      - api-usage=26/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:28 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:49 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_Salesforce_record/returns_the_attributes_from_the_Salesforce_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:45 GMT
+      - Wed, 10 Jun 2015 20:32:51 GMT
       Set-Cookie:
-      - BrowserId=WKJBDf2wS9yoOjMIgd5GVg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:45 GMT
+      - BrowserId=VUztcA6iRlGDBRaknItakA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:51 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801565981","token_type":"Bearer","instance_url":"https://<host>","signature":"tcufiqR1IVzUzMvBFfvPgcLtI2Xh/s0F+UZJ22yVee0=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433968371999","token_type":"Bearer","instance_url":"https://<host>","signature":"Gdo4VHqHus3ySFTTeVS1NBTTeTOcpAxwrCNjZIJrh9E=","access_token":"00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:52 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:46 GMT
+      - Wed, 10 Jun 2015 20:32:52 GMT
       Set-Cookie:
-      - BrowserId=bxs8gUr1T-2ytKX8wxVUrQ;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:46 GMT
+      - BrowserId=OK9bQk3lSAytj-uLDKBRzg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:52 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=29/15000
+      - api-usage=26/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNU2AAM"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000001cF5tAAE","success":true,"errors":[]}'
+      string: '{"id":"a001a000001cNU2AAM","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:53 GMT
 - request:
     method: get
-    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cF5tAAE%27
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c%20where%20Id%20=%20%27a001a000001cNU2AAM%27
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,10 +103,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:46 GMT
+      - Wed, 10 Jun 2015 20:32:53 GMT
       Set-Cookie:
-      - BrowserId=vQbLE1ABSQuNHocFh6nwqg;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:46 GMT
+      - BrowserId=-asaRzgaTIeZsCe8KyGMdg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:53 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
@@ -117,10 +117,10 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"},"Id":"a001a000001cF5tAAE","SystemModstamp":"2015-06-08T22:12:46.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNU2AAM"},"Id":"a001a000001cNU2AAM","SystemModstamp":"2015-06-10T20:32:52.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:47 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:53 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
@@ -131,7 +131,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -142,27 +142,27 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:46 GMT
+      - Wed, 10 Jun 2015 20:32:54 GMT
       Set-Cookie:
-      - BrowserId=q3u3iCrgSqaR3zeQeQ284Q;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:46 GMT
+      - BrowserId=E_Ig06iqR46y3L2bOPDuqg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:54 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=27/15000
+      - api-usage=29/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":2,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null},{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE"},"Id":"a001a000001cF5tAAE","SystemModstamp":"2015-06-08T22:12:46.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNU2AAM"},"Id":"a001a000001cNU2AAM","SystemModstamp":"2015-06-10T20:32:52.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
         object","Example_Field__c":"Some sample text"}]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:54 GMT
 - request:
-    method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cF5tAAE
+    method: get
+    uri: https://<host>/services/data/<api_version>/
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,83 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:32:55 GMT
+      Set-Cookie:
+      - BrowserId=zGfAmh7wQiaDTLAhC3fFlA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=28/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"limits":"/services/data/<api_version>/limits","sobjects":"/services/data/<api_version>/sobjects","connect":"/services/data/<api_version>/connect","query":"/services/data/<api_version>/query","theme":"/services/data/<api_version>/theme","queryAll":"/services/data/<api_version>/queryAll","tooling":"/services/data/<api_version>/tooling","chatter":"/services/data/<api_version>/chatter","analytics":"/services/data/<api_version>/analytics","recent":"/services/data/<api_version>/recent","commerce":"/services/data/<api_version>/commerce","licensing":"/services/data/<api_version>/licensing","identity":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","flexiPage":"/services/data/<api_version>/flexiPage","search":"/services/data/<api_version>/search","quickActions":"/services/data/<api_version>/quickActions","appMenu":"/services/data/<api_version>/appMenu"}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:32:55 GMT
+- request:
+    method: get
+    uri: https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:32:55 GMT
+      - Wed, 10 Jun 2015 20:32:55 GMT
+      Set-Cookie:
+      - BrowserId=Y6ll11VqRRum-UtA8HbU_Q;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:55 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","asserted_user":true,"user_id":"0051a000000UGT8AAO","organization_id":"00D1a000000H3O9EAK","username":"andrew+salesforce@tablexi.com","nick_name":"andrew+salesforce1.42656567106328E12","display_name":"Andrew
+        Horner","email":"andrew@tablexi.com","email_verified":true,"first_name":"Andrew","last_name":"Horner","timezone":"America/Los_Angeles","photos":{"picture":"https://c.na24.content.force.com/profilephoto/005/F","thumbnail":"https://c.na24.content.force.com/profilephoto/005/T"},"addr_street":null,"addr_city":null,"addr_state":null,"addr_country":"US","addr_zip":"60661","mobile_phone":null,"mobile_phone_verified":false,"status":{"created_date":null,"body":null},"urls":{"enterprise":"https://<host>/services/Soap/c/{version}/00D1a000000H3O9","metadata":"https://<host>/services/Soap/m/{version}/00D1a000000H3O9","partner":"https://<host>/services/Soap/u/{version}/00D1a000000H3O9","rest":"https://<host>/services/data/v{version}/","sobjects":"https://<host>/services/data/v{version}/sobjects/","search":"https://<host>/services/data/v{version}/search/","query":"https://<host>/services/data/v{version}/query/","recent":"https://<host>/services/data/v{version}/recent/","profile":"https://<host>/0051a000000UGT8AAO","feeds":"https://<host>/services/data/v{version}/chatter/feeds","groups":"https://<host>/services/data/v{version}/chatter/groups","users":"https://<host>/services/data/v{version}/chatter/users","feed_items":"https://<host>/services/data/v{version}/chatter/feed-items"},"active":true,"user_type":"STANDARD","language":"en_US","locale":"en_US","utcOffset":-28800000,"last_modified_date":"2015-03-17T04:14:23.000+0000","is_app_installed":true}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:32:55 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNU2AAM
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -181,17 +257,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:46 GMT
+      - Wed, 10 Jun 2015 20:32:56 GMT
       Set-Cookie:
-      - BrowserId=k05v9q6lRV6J82d_MPkehw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:46 GMT
+      - BrowserId=VBeEZYY_S0m1i9-4L3t9Nw;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:56 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=24/15000
+      - api-usage=29/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:48 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:56 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/given_an_existing_database_record/returns_the_attributes_from_the_database_record.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:26 GMT
+      - Wed, 10 Jun 2015 20:32:39 GMT
       Set-Cookie:
-      - BrowserId=FXMQW0CNQ-CxdRdIg0pZyw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:26 GMT
+      - BrowserId=OzqGjtRRQqOYsArDRNVlkA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:39 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433801546149","token_type":"Bearer","instance_url":"https://<host>","signature":"OpfQrQSzS7CXjr7GajZRRWSr46FQiYAZKJajUpjOWBU=","access_token":"00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433968359761","token_type":"Bearer","instance_url":"https://<host>","signature":"V0sVcn9qlcfjabLoXSB5KJgn+fLZCa+yElZIcLic0Nc=","access_token":"00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ"}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:39 GMT
 - request:
     method: get
     uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
@@ -50,7 +50,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQH0rZGqBVji7vO4sB8J1_YW.g5S2vIbe9IaUgwHpwLPEdpfIcj9Ngpc2CndFvJZMwVIIp15.yQQOil19Qc2MuedbnlQz
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -61,21 +61,21 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 08 Jun 2015 22:12:26 GMT
+      - Wed, 10 Jun 2015 20:32:40 GMT
       Set-Cookie:
-      - BrowserId=dM5SIvpNQp6Hdo3R5FfeWw;Path=/;Domain=.salesforce.com;Expires=Fri,
-        07-Aug-2015 22:12:26 GMT
+      - BrowserId=xfRCkoPlRqmvZ0Tzaw788w;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:32:40 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=10/15000
+      - api-usage=26/15000
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001a60JAAQ"},"Id":"a001a000001a60JAAQ","SystemModstamp":"2015-05-18T22:46:05.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"SAMPLE","Example_Field__c":null}]}'
+      string: '{"totalSize":0,"done":true,"records":[]}'
     http_version: 
-  recorded_at: Mon, 08 Jun 2015 22:12:27 GMT
+  recorded_at: Wed, 10 Jun 2015 20:32:40 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Collector/_run/when_the_record_has_not_been_updated_outside_of_the_system/does_not_collect_any_changes.yml
+++ b/test/cassettes/Restforce_DB_Collector/_run/when_the_record_has_not_been_updated_outside_of_the_system/does_not_collect_any_changes.yml
@@ -1,0 +1,158 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<host>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<client_id>&client_secret=<client_secret>&username=<username>&password=<password><security_token>
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:35:23 GMT
+      Set-Cookie:
+      - BrowserId=BVq3r9U3TByDBBgjrX9ZwQ;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:35:23 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1433968523424","token_type":"Bearer","instance_url":"https://<host>","signature":"aFumcItqbbwyu+qYnEKWruhzcfirRdtUAenArGDX2b4=","access_token":"00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ"}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:35:23 GMT
+- request:
+    method: post
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
+    body:
+      encoding: UTF-8
+      string: '{"Name":"Custom object","Example_Field__c":"Some sample text"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:35:24 GMT
+      Set-Cookie:
+      - BrowserId=pLhYUJXqRiWwbQfqKyu2vA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:35:24 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=37/15000
+      Location:
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNUCAA2"
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"a001a000001cNUCAA2","success":true,"errors":[]}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:35:24 GMT
+- request:
+    method: get
+    uri: https://<host>/services/data/<api_version>/query?q=select%20Id,%20SystemModstamp,%20LastModifiedById,%20Name,%20Example_Field__c%20from%20CustomObject__c
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:35:25 GMT
+      Set-Cookie:
+      - BrowserId=lDZ7sSyzSJymo8s8p2dGAA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:35:25 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=37/15000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"CustomObject__c","url":"/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNUCAA2"},"Id":"a001a000001cNUCAA2","SystemModstamp":"2015-06-10T20:35:24.000+0000","LastModifiedById":"0051a000000UGT8AAO","Name":"Custom
+        object","Example_Field__c":"Some sample text"}]}'
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:35:25 GMT
+- request:
+    method: delete
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000001cNUCAA2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.1
+      Authorization:
+      - OAuth 00D1a000000H3O9!AQ4AQGzO6cHltgvJmAqci.NyJL0_69pRzwnlpfIuBhSFZZ9eTNfL3boDM7Q1rZgxPeBiO43MEzeFl0F6uHCKElAgVLWxmICJ
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Wed, 10 Jun 2015 20:35:26 GMT
+      Set-Cookie:
+      - BrowserId=Fz1dEybBSvuz5XHirYZyng;Path=/;Domain=.salesforce.com;Expires=Sun,
+        09-Aug-2015 20:35:26 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=37/15000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 10 Jun 2015 20:35:26 GMT
+recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/collector_test.rb
+++ b/test/lib/restforce/db/collector_test.rb
@@ -85,5 +85,19 @@ describe Restforce::DB::Collector do
       end
     end
 
+    describe "when the record has not been updated outside of the system" do
+      subject do
+        Restforce::DB::Runner.stub_any_instance(:changed?, false) do
+          collector.run
+        end
+      end
+
+      before { salesforce_id }
+
+      it "does not collect any changes" do
+        expect(subject[key]).to_be :empty?
+      end
+    end
+
   end
 end

--- a/test/lib/restforce/db/record_cache_test.rb
+++ b/test/lib/restforce/db/record_cache_test.rb
@@ -1,11 +1,11 @@
 require_relative "../../../test_helper"
 
-describe Restforce::DB::RunnerCache do
+describe Restforce::DB::RecordCache do
 
   configure!
   mappings!
 
-  let(:cache) { Restforce::DB::RunnerCache.new }
+  let(:cache) { Restforce::DB::RecordCache.new }
 
   describe "#collection" do
     let(:object) { mapping.database_model.create! }

--- a/test/lib/restforce/db/timestamp_cache_test.rb
+++ b/test/lib/restforce/db/timestamp_cache_test.rb
@@ -1,0 +1,86 @@
+require_relative "../../../test_helper"
+
+describe Restforce::DB::TimestampCache do
+
+  configure!
+
+  let(:cache) { Restforce::DB::TimestampCache.new }
+
+  let(:timestamp) { Time.now }
+  let(:id) { "some-id" }
+  let(:instance_class) { Struct.new(:id, :last_update) }
+  let(:instance) { instance_class.new(id, timestamp) }
+
+  describe "#update" do
+    before { cache.update instance }
+
+    it "stores the update timestamp in the cache" do
+      expect(cache.timestamp(instance)).to_equal timestamp
+    end
+  end
+
+  describe "#changed?" do
+    let(:new_instance) { instance_class.new(id, timestamp) }
+
+    describe "when the passed instance was not internally updated" do
+      before do
+        def new_instance.updated_internally?
+          false
+        end
+      end
+
+      it "returns true" do
+        expect(cache).to_be :changed?, new_instance
+      end
+    end
+
+    describe "when the passed instance was internally updated" do
+      before do
+        def new_instance.updated_internally?
+          true
+        end
+      end
+
+      describe "but no update timestamp is cached" do
+
+        it "returns true" do
+          expect(cache).to_be :changed?, new_instance
+        end
+      end
+
+      describe "and a recent timestamp is cached" do
+        before { cache.update instance }
+
+        it "returns false" do
+          expect(cache).to_not_be :changed?, new_instance
+        end
+      end
+
+      describe "and a stale timestamp is cached" do
+        let(:new_instance) { instance_class.new(id, timestamp + 1) }
+        before { cache.update instance }
+
+        it "returns true" do
+          expect(cache).to_be :changed?, new_instance
+        end
+      end
+    end
+  end
+
+  describe "#reset" do
+    before do
+      cache.update instance
+      cache.reset
+    end
+
+    it "retires recently-stored timestamps" do
+      expect(cache.timestamp(instance)).to_equal timestamp
+    end
+
+    it "expires old timestamps" do
+      cache.reset
+      expect(cache.timestamp(instance)).to_be_nil
+    end
+  end
+
+end

--- a/test/lib/restforce/db/timestamp_cache_test.rb
+++ b/test/lib/restforce/db/timestamp_cache_test.rb
@@ -11,8 +11,8 @@ describe Restforce::DB::TimestampCache do
   let(:instance_class) { Struct.new(:id, :last_update) }
   let(:instance) { instance_class.new(id, timestamp) }
 
-  describe "#update" do
-    before { cache.update instance }
+  describe "#cache_timestamp" do
+    before { cache.cache_timestamp instance }
 
     it "stores the update timestamp in the cache" do
       expect(cache.timestamp(instance)).to_equal timestamp
@@ -49,7 +49,7 @@ describe Restforce::DB::TimestampCache do
       end
 
       describe "and a recent timestamp is cached" do
-        before { cache.update instance }
+        before { cache.cache_timestamp instance }
 
         it "returns false" do
           expect(cache).to_not_be :changed?, new_instance
@@ -58,7 +58,7 @@ describe Restforce::DB::TimestampCache do
 
       describe "and a stale timestamp is cached" do
         let(:new_instance) { instance_class.new(id, timestamp + 1) }
-        before { cache.update instance }
+        before { cache.cache_timestamp instance }
 
         it "returns true" do
           expect(cache).to_be :changed?, new_instance
@@ -69,7 +69,7 @@ describe Restforce::DB::TimestampCache do
 
   describe "#reset" do
     before do
-      cache.update instance
+      cache.cache_timestamp instance
       cache.reset
     end
 
@@ -77,7 +77,7 @@ describe Restforce::DB::TimestampCache do
       expect(cache.timestamp(instance)).to_equal timestamp
     end
 
-    it "expires old timestamps" do
+    it "expires retired timestamps" do
       cache.reset
       expect(cache.timestamp(instance)).to_be_nil
     end

--- a/test/support/salesforce.rb
+++ b/test/support/salesforce.rb
@@ -36,7 +36,6 @@ class Salesforce
   #
   # Returns nothing.
   def self.clean!
-    # raise Salesforce.records.inspect unless Salesforce.records.empty?
     Salesforce.records.each do |entry|
       Restforce::DB.client.destroy entry[0], entry[1]
     end


### PR DESCRIPTION
While we can tell which user _triggered_ the most recent changes to a
record in Salesforce, we can’t tell if any modifications to that record
were a result of a background Apex trigger or workflow (which apply any
changes as if they were the user whose actions initiated the callback).

In order to distinguish between updates made _by_ the worker and updates
made _in response to_ changes by the worker, we have to check the 
record’s update timestamp against the timestamp of the last known update
made by the system. `TimestampCache` serves as a mechanism to track the
values for this comparison.

When we collect changes for our mappings, we want to disregard any 
changes which were introduced as part of Restforce::DB’s synchronization
process — these changes may be stale, relative to changes introduced by
the user during the course of the previous sync loop.