### PR TITLE
Add a default timeout to the client configuration

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -90,6 +90,7 @@ module Restforce
         client_secret:  configuration.client_secret,
         host:           configuration.host,
         api_version:    configuration.api_version,
+        timeout:        configuration.timeout,
       )
     end
 

--- a/lib/restforce/db/configuration.rb
+++ b/lib/restforce/db/configuration.rb
@@ -9,6 +9,7 @@ module Restforce
     class Configuration
 
       DEFAULT_API_VERSION = "29.0".freeze
+      DEFAULT_TIMEOUT     = 5
 
       attr_accessor(*%i(
         username
@@ -17,6 +18,7 @@ module Restforce
         client_id
         client_secret
         host
+        timeout
         api_version
         logger
       ))
@@ -73,6 +75,7 @@ module Restforce
         # We want to default to 29.0 or later, so we can support the API
         # endpoint for recently deleted records.
         self.api_version    = configurations["api_version"] || DEFAULT_API_VERSION
+        self.timeout        = configurations["timeout"] || DEFAULT_TIMEOUT
       end
 
       private

--- a/test/lib/restforce/db/configuration_test.rb
+++ b/test/lib/restforce/db/configuration_test.rb
@@ -68,6 +68,14 @@ describe Restforce::DB::Configuration do
         expect(configuration.client_secret).to_equal secrets["client_secret"]
         expect(configuration.host).to_equal secrets["host"]
       end
+
+      it "defaults the API version to DEFAULT_API_VERSION" do
+        expect(configuration.api_version).to_equal Restforce::DB::Configuration::DEFAULT_API_VERSION
+      end
+
+      it "defaults the timeout to DEFAULT_TIMEOUT" do
+        expect(configuration.timeout).to_equal Restforce::DB::Configuration::DEFAULT_TIMEOUT
+      end
     end
 
     describe "when the loaded configuration is missing one or more keys" do


### PR DESCRIPTION
By default, Restforce’s Faraday client does not configure a timeout for
its requests, which can result in the process apparently hanging while
it waits for a request that will never finish.

Since we’re trying to keep our polling loop tight, it makes sense for us
to time out requests in relatively short order — five seconds (our 
default target synchronization loop time) is perhaps _too_ generous, but
should at the very least prevent the worker from getting locked up.