### PR TITLE
Split out “safe” and “non-safe” reset methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ restaurant.force_sync!
 
 You'll need to ensure that Restforce::DB is properly configured for your application (an initializer is recommended).
 
+#### Testing
+
+If you're testing your integration, and using something like VCR to record your specs, you may run into some spec order dependency issues due to Restforce::DB's global request caching. To prevent these dependencies in your spec suite, you can clear all cached data by invoking `Restforce::DB.reset` somewhere in your spec setup or teardown.
+
 ## System Caveats
 
 - **API Usage.** 

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -113,14 +113,31 @@ module Restforce
       configuration
     end
 
-    # Public: Eliminate all customizations to the current Restforce::DB
-    # configuration and client.
+    # Public: Clear all globally cached values for Restforce::DB.
+    #
+    # NOTE: This is an "idempotent" reset; following invocation, all functions
+    # should still work as before, but globally cached values will be
+    # repopulated.
     #
     # Returns nothing.
     def self.reset
-      @configuration = nil
-      @client = nil
+      FieldProcessor.reset
       @user_id = nil
+      @client = nil
+    end
+
+    # Public: Eliminate all customizations to the current Restforce::DB
+    # configuration and client.
+    #
+    # NOTE: This is a hard reset; following invocation, Restforce::DB will need
+    # to be reconfigured in order for functionality to be restored.
+    #
+    # Returns nothing.
+    def self.reset!
+      reset
+
+      @configuration = nil
+      @last_run = nil
     end
 
   end

--- a/test/support/utilities.rb
+++ b/test/support/utilities.rb
@@ -5,13 +5,11 @@ def configure!
   end
 
   after do
-    Restforce::DB::FieldProcessor.reset
-    Restforce::DB::Registry.clean!
-    Restforce::DB.last_run = nil
-    Restforce::DB.logger = nil
-
     DatabaseCleaner.clean
     Salesforce.clean!
+
+    Restforce::DB::Registry.clean!
+    Restforce::DB.reset!
   end
 end
 


### PR DESCRIPTION
To make it easy for users of Restforce::DB to test its functionality
in a consistent way, we need to simplify the manner in which globally-
cached data and requests are reset.

The existing `Restforce::DB.reset` method has been repurposed for this
“safe” reset, while the more destructive reset functionality has been 
tucked into a new `Restforce::DB.reset!` method.