### PR TITLE
Prevent unnecessary record re-Association

### DIFF
--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -66,7 +66,7 @@ module Restforce
             # for what is actually a one-to-many association on the
             # ActiveRecord object, so we always treat the result as an Array.
             associated = Array(database_record.association(name).reader)
-            ids[lookup] = associated.empty? ? nil : associated.first.send(mapping.lookup_column)
+            ids[lookup] = associated.first.send(mapping.lookup_column) unless associated.empty?
           end
 
           ids

--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -95,12 +95,13 @@ module Restforce
       end
 
       # Internal: Get a list of the BelongsTo associations defined for the
-      # target mapping.
+      # target mapping. Ignores associations where the foreign key is Id, as
+      # a record's Id will never change.
       #
       # Returns an Array of Restforce::DB::Association::BelongsTo objects.
       def belongs_to_associations
         @belongs_to_associations ||= @mapping.associations.select do |association|
-          association.is_a?(Restforce::DB::Associations::BelongsTo)
+          association.is_a?(Restforce::DB::Associations::BelongsTo) && association.lookup != "Id"
         end
       end
 

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -33,6 +33,8 @@ module Restforce
         return unless @mapping.strategy.build?(instance)
 
         created = @mapping.database_record_type.create!(instance)
+
+        @runner.cache_timestamp instance
         @runner.cache_timestamp created
       rescue ActiveRecord::ActiveRecordError => e
         DB.logger.error(SynchronizationError.new(e, instance))
@@ -49,6 +51,8 @@ module Restforce
         return if instance.synced?
 
         created = @mapping.salesforce_record_type.create!(instance)
+
+        @runner.cache_timestamp instance
         @runner.cache_timestamp created
       rescue Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -75,12 +75,12 @@ module Restforce
             run("ATTACHING RECORDS", Attacher, mapping)
             run("PROPAGATING RECORDS", Initializer, mapping)
             run("COLLECTING CHANGES", Collector, mapping)
-            run("UPDATING ASSOCIATIONS", Associator, mapping)
           end
 
           # NOTE: We can only perform the synchronization after all record
           # changes have been aggregated, so this second loop is necessary.
           Restforce::DB::Registry.each do |mapping|
+            run("UPDATING ASSOCIATIONS", Associator, mapping)
             run("APPLYING CHANGES", Synchronizer, mapping)
           end
         end

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_no_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/and_the_underlying_association_is_one-to-many/still_returns_no_value_in_the_hash.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:54:59 GMT
+      - Wed, 01 Jul 2015 22:21:59 GMT
       Set-Cookie:
-      - BrowserId=PiXgo3-8QbWuN06OMsqyEg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:54:59 GMT
+      - BrowserId=pSV4lvHNQnW2bmTjXxurMA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:21:59 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1435269299946","token_type":"Bearer","instance_url":"https://<host>","signature":"QBli7y/0oiV6hAslccEqjbViwiPNKNC2uh3fhx3hn3A=","access_token":"00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1435789319584","token_type":"Bearer","instance_url":"https://<host>","signature":"IR8FX61zjomHUYcHXhnxA8c2OlpArSm/29OXS6TXI5A=","access_token":"00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g"}'
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:00 GMT
+  recorded_at: Wed, 01 Jul 2015 22:21:59 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA
+      - OAuth 00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:55:00 GMT
+      - Wed, 01 Jul 2015 22:22:00 GMT
       Set-Cookie:
-      - BrowserId=iEzyEGpKQxeERiy08x91bg;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:55:00 GMT
+      - BrowserId=U6tImumuReGJF-zS-Ebehg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:22:00 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=145/15000
+      - api-usage=7/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000002zhZoAAI"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a00000309IXAAY"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000002zhZoAAI","success":true,"errors":[]}'
+      string: '{"id":"a001a00000309IXAAY","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:00 GMT
+  recorded_at: Wed, 01 Jul 2015 22:22:00 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000002zhZoAAI
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a00000309IXAAY
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA
+      - OAuth 00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,17 +103,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:55:00 GMT
+      - Wed, 01 Jul 2015 22:22:01 GMT
       Set-Cookie:
-      - BrowserId=HNcH22aHRrC_YIanhNh0dA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:55:00 GMT
+      - BrowserId=ExR5pJi2RHGsmv5WrGqJ6g;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:22:01 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=146/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:01 GMT
+  recorded_at: Wed, 01 Jul 2015 22:22:01 GMT
 recorded_with: VCR 2.9.3

--- a/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_no_value_in_the_hash.yml
+++ b/test/cassettes/Restforce_DB_Associations_BelongsTo/with_an_inverse_mapping/_lookups/when_there_is_currently_no_associated_record/returns_no_value_in_the_hash.yml
@@ -21,10 +21,10 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:55:07 GMT
+      - Wed, 01 Jul 2015 22:22:03 GMT
       Set-Cookie:
-      - BrowserId=c3tk_yLaSbugLEy7ZHfN0g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:55:07 GMT
+      - BrowserId=qGHLRZezTjOQaFra2D9NGg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:22:03 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Pragma:
@@ -37,9 +37,9 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1435269308063","token_type":"Bearer","instance_url":"https://<host>","signature":"oz5BIcQcl/oR4S8ti3lhZy2nj0bQilvb2m6YFaVBFbE=","access_token":"00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA"}'
+      string: '{"id":"https://login.salesforce.com/id/00D1a000000H3O9EAK/0051a000000UGT8AAO","issued_at":"1435789323964","token_type":"Bearer","instance_url":"https://<host>","signature":"vfN4LijqlTxjHAcDWDjrwczNUgVgtpNxMVcf6IT0H2Q=","access_token":"00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g"}'
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:08 GMT
+  recorded_at: Wed, 01 Jul 2015 22:22:03 GMT
 - request:
     method: post
     uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c
@@ -52,7 +52,7 @@ http_interactions:
       Content-Type:
       - application/json
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA
+      - OAuth 00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -63,28 +63,28 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:55:08 GMT
+      - Wed, 01 Jul 2015 22:22:04 GMT
       Set-Cookie:
-      - BrowserId=KMcbDqlmQlqnUw8JfdRg8g;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:55:08 GMT
+      - BrowserId=bgHJK63LRWaIlTO2E2U0QA;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:22:04 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=190/15000
+      - api-usage=8/15000
       Location:
-      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a000002zhXoAAI"
+      - "/services/data/<api_version>/sobjects/CustomObject__c/a001a00000309IcAAI"
       Content-Type:
       - application/json;charset=UTF-8
       Transfer-Encoding:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"a001a000002zhXoAAI","success":true,"errors":[]}'
+      string: '{"id":"a001a00000309IcAAI","success":true,"errors":[]}'
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:08 GMT
+  recorded_at: Wed, 01 Jul 2015 22:22:05 GMT
 - request:
     method: delete
-    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a000002zhXoAAI
+    uri: https://<host>/services/data/<api_version>/sobjects/CustomObject__c/a001a00000309IcAAI
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
       User-Agent:
       - Faraday v0.9.1
       Authorization:
-      - OAuth 00D1a000000H3O9!AQ4AQIEnz7RMa1N2z10U8y.cU3CAaZeOCxcDVSetug6psPcDYNjSbdC91y8MHqmZ.ZXE_zkQURv2YNCWYEsl0fcbZwb1MPEA
+      - OAuth 00D1a000000H3O9!AQ4AQKJZZLBvLm3vEyoa1I_FUwCVKJTQydGXcIOYHXeuNRsEB5WSOXQC2x.kIQ3wbc1V_KhljRRKg43aIkvmAoiG.a4Ll49g
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -103,17 +103,17 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Thu, 25 Jun 2015 21:55:08 GMT
+      - Wed, 01 Jul 2015 22:22:06 GMT
       Set-Cookie:
-      - BrowserId=1gCPQMOtTb2BQFtEeSfgAA;Path=/;Domain=.salesforce.com;Expires=Mon,
-        24-Aug-2015 21:55:08 GMT
+      - BrowserId=bEI3cWD_SaCpOD8wvl95jg;Path=/;Domain=.salesforce.com;Expires=Sun,
+        30-Aug-2015 22:22:06 GMT
       Expires:
       - Thu, 01 Jan 1970 00:00:00 GMT
       Sforce-Limit-Info:
-      - api-usage=204/15000
+      - api-usage=7/15000
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Thu, 25 Jun 2015 21:55:09 GMT
+  recorded_at: Wed, 01 Jul 2015 22:22:06 GMT
 recorded_with: VCR 2.9.3

--- a/test/lib/restforce/db/associations/belongs_to_test.rb
+++ b/test/lib/restforce/db/associations/belongs_to_test.rb
@@ -57,8 +57,8 @@ describe Restforce::DB::Associations::BelongsTo do
         let(:object_salesforce_id) { Salesforce.create!(mapping.salesforce_model) }
         let(:object) { mapping.database_model.create!(salesforce_id: object_salesforce_id) }
 
-        it "returns a nil lookup value in the hash" do
-          expect(association.lookups(object)).to_equal("Friend__c" => nil)
+        it "returns no value in the hash" do
+          expect(association.lookups(object)).to_be :empty?
         end
 
         describe "and the underlying association is one-to-many" do
@@ -73,8 +73,8 @@ describe Restforce::DB::Associations::BelongsTo do
             end
           end
 
-          it "still returns a nil lookup value in the hash" do
-            expect(association.lookups(object)).to_equal("Friend__c" => nil)
+          it "still returns no value in the hash" do
+            expect(association.lookups(object)).to_be :empty?
           end
         end
       end

--- a/test/lib/restforce/db/associator_test.rb
+++ b/test/lib/restforce/db/associator_test.rb
@@ -39,6 +39,14 @@ describe Restforce::DB::Associator do
         mapping.associations << association
       end
 
+      describe "when the association lookup is through Id" do
+        let(:association) { Restforce::DB::Associations::BelongsTo.new(:user, through: "Id") }
+
+        it "ignores the association" do
+          expect(associator.send(:belongs_to_associations)).to_be :empty?
+        end
+      end
+
       describe "given another record for association" do
         let(:new_user_salesforce_id) do
           Salesforce.create!(


### PR DESCRIPTION
We've discovered a handful of quirks which can result in newly-propagated Salesforce records being immediately touched by the `Associator`. This seems relatively harmless, but doesn't need to happen, and can trigger some alarming exceptions (such as the `RecordsChanged` error in `Cleaner`).

This PR takes a stab at eliminating the issue from multiple angles, and generally makes the `Associator` more reliable and less quirky.