### PR TITLE
Consult all cached records during BelongsTo#build

### DIFF
--- a/lib/restforce/db/associations/belongs_to.rb
+++ b/lib/restforce/db/associations/belongs_to.rb
@@ -32,7 +32,7 @@ module Restforce
 
             # If the referenced database record already exists, we can short-
             # circuit the accumulation of attributes here.
-            next if mapping.database_model.exists?(mapping.lookup_column => lookup_id)
+            next if cache.find(mapping.database_model, mapping.lookup_column => lookup_id)
 
             instance = mapping.salesforce_record_type.find(lookup_id)
 


### PR DESCRIPTION
When we have already cached an unpersisted database record during our
association-building process, we can short-circuit the related HTTP 
requests. This should cut down on extraneous API calls made during 
the initial sync for a record.