### PR TITLE
Ensure proper three-digit hash for Salesforce IDs

### DIFF
--- a/lib/tasks/restforce.rake
+++ b/lib/tasks/restforce.rake
@@ -31,11 +31,7 @@ namespace :restforce do
         flag += (1 << idx) if char.upcase == char && char >= "A" && char <= "Z"
       end
 
-      if flag <= 25
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[flag]
-      else
-        "012345"[flag - 25]
-      end
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"[flag]
     end
 
     puts sfid + suffixes.join


### PR DESCRIPTION
A record ID with a large number of capital letters in a single chunk
would trip into the numeric flags, where we have an off-by-one error.
Silly stuff.