### PR TITLE
Add restforce:populate rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,19 @@ The task takes several arguments, most of which are optional:
 - `end_time` (optional): The latest point in time for which records should be gathered.
 - `config` (optional): The path to the file containing your Restforce::DB credentials. If not explicitly provided, the default installation file path (see above) will be used.
 
+### Pull down missing fields
+
+To populate existing synchronized records with data from newly-mapped fields, you can run the `populate` rake task. This will iterate through _all_ records in your database for the specified model, and populate the specified field on each record. This could potentially take a while if you have a large number of
+records.
+
+    $ bundle exec rake restforce:populate[<model>,<salesforce_model>,<field>]
+
+This task takes a handful of required arguments:
+
+- `model`: The name of the ActiveRecord model you wish to sync. This can be any model you've defined a mapping for in your application.
+- `salesforce_model`: The name of the specfic Salesforce model to which the desired field is mapped. This object type will be used as the data source.
+- `field`: The name of the attribute to populate on your ActiveRecord model. Will usually correspond to a database column name.
+
 ### Run the daemon
 
 To actually perform this system synchronization, you'll want to run the binstub installed through the generator (see above). This will daemonize a process which loops repeatedly to continuously synchronize your database and your Salesforce account, according to the established mappings.

--- a/lib/tasks/restforce.rake
+++ b/lib/tasks/restforce.rake
@@ -18,6 +18,34 @@ namespace :restforce do
     end
   end
 
+  desc "Pull down the requested Salesforce data for the specified model"
+  task :populate, [:model, :salesforce_model, :field] => :environment do |_, args|
+    raise ArgumentError, "An ActiveRecord model name must be supplied" unless args[:model]
+    raise ArgumentError, "A Salesforce model name must be supplied" unless args[:salesforce_model]
+    raise ArgumentError, "An attribute name must be supplied" unless args[:field]
+
+    Rails.application.eager_load!
+
+    model = args[:model].constantize
+    field = args[:field].to_sym
+
+    mapping = Restforce::DB::Registry[model].detect do |m|
+      m.salesforce_model == args[:salesforce_model]
+    end
+
+    raise ArgumentError, "No Mapping was found between #{args[:model]} and #{args[:salesforce_model]}" unless mapping
+
+    model.where.not(mapping.lookup_column => nil).find_each do |record|
+      salesforce_id = record.send(mapping.lookup_column)
+      salesforce_instance = mapping.salesforce_record_type.find(salesforce_id)
+      next unless salesforce_instance
+
+      attributes = mapping.convert(model, salesforce_instance.attributes)
+      record.update!(field => attributes[field])
+      record.touch(:synchronized_at)
+    end
+  end
+
   desc "Get the 18-character version of a 15-character Salesforce ID"
   task :convertid, [:salesforce_id] do |_, args|
     sfid = args[:salesforce_id]

--- a/lib/tasks/restforce.rake
+++ b/lib/tasks/restforce.rake
@@ -41,8 +41,7 @@ namespace :restforce do
       next unless salesforce_instance
 
       attributes = mapping.convert(model, salesforce_instance.attributes)
-      record.update!(field => attributes[field])
-      record.touch(:synchronized_at)
+      record.update_columns field => attributes[field]
     end
   end
 


### PR DESCRIPTION
As a project continues to grow, it may often be necessary to add new
fields to one or more existing mappings. To ease the tedium of 
constantly resetting the database or manually populating information,
we can introduce a rake task to perform a one-time initial seed of data
for individual fields.