### PR TITLE
Prevent disruptive exception bubbling in tasks

### DIFF
--- a/lib/restforce/db/associator.rb
+++ b/lib/restforce/db/associator.rb
@@ -39,6 +39,10 @@ module Restforce
         return unless database_instance && salesforce_instance
 
         sync_associations(database_instance, salesforce_instance)
+      rescue Faraday::Error::ClientError => e
+        # This should only be tripped if `synchronized_instances` makes a
+        # request to fetch the Salesforce instance.
+        DB.logger.error(SynchronizationError.new(e, database_instance))
       end
 
       # Internal: Given an instance for one system, find its synchronized pair

--- a/lib/restforce/db/initializer.rb
+++ b/lib/restforce/db/initializer.rb
@@ -36,7 +36,7 @@ module Restforce
 
         @runner.cache_timestamp instance
         @runner.cache_timestamp created
-      rescue ActiveRecord::ActiveRecordError => e
+      rescue ActiveRecord::ActiveRecordError, Faraday::Error::ClientError => e
         DB.logger.error(SynchronizationError.new(e, instance))
       end
 


### PR DESCRIPTION
There are a handful of places where we don’t currently rescue out of
Timeout errors, which results in records (and even entire tasks) being 
skipped wholesale. This addresses the problem at two levels:

1. Ensure that each task rescues out of Faraday errors at the instance
  level when possible. This will allow subsequent instances to be
  processed even when one fails.
2. Properly report top-level task failures — typically hit when querying
  for a collection of Salesforce instances. This should improve our 
  output from a debugging standpoint, and allow subsequent tasks to 
  carry out their jobs even when one fails.