### PR TITLE
Ensure proper position of Faraday retry middleware

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -100,8 +100,9 @@ module Restforce
         # NOTE: By default, the Retry middleware will catch timeout exceptions,
         # and retry up to two times. For more information, see:
         # https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb
-        client.middleware.request(
-          :retry,
+        client.middleware.insert(
+          -2,
+          Faraday::Request::Retry,
           methods: [:get, :head, :options, :put, :patch, :delete],
         )
 

--- a/test/lib/restforce/db_test.rb
+++ b/test/lib/restforce/db_test.rb
@@ -13,6 +13,21 @@ describe Restforce::DB do
     end
   end
 
+  describe "#client" do
+    before do
+      Restforce::DB.configure do |config|
+        config.adapter = :net_http
+      end
+    end
+
+    it "adds the Retry middleware before the adapter" do
+      handlers = Restforce::DB.client.middleware.handlers
+
+      expect(handlers[-2].klass).to_equal(Faraday::Request::Retry)
+      expect(handlers[-1].klass).to_equal(Faraday::Adapter::NetHttp)
+    end
+  end
+
   describe "accessing Salesforce", :vcr do
 
     it "uses the configured credentials" do


### PR DESCRIPTION
If the retry middleware is added _after_ the adapter, it will never have
a chance to actually rescue out of timeout errors triggered _by_ the
adapter.