### PR TITLE
Instrument API interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ If you're testing your integration, and using something like VCR to record your 
 
   Restforce::DB attempts to mitigate this effect by tracking change timestamps for internal updates.
 
+## Instrumentation
+
+Restforce::DB uses a [Faraday](https://github.com/lostisland/faraday) middleware to add API interaction [instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb), as described in [Restforce's documentation](https://github.com/ejholmes/restforce#loggingdebugginginstrumenting) through [Active Support notifications](http://guides.rubyonrails.org/active_support_instrumentation.html).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -97,29 +97,34 @@ module Restforce
           timeout:        configuration.timeout,
           adapter:        configuration.adapter,
         )
-
-        # NOTE: By default, the Retry middleware will catch timeout exceptions,
-        # and retry up to two times. For more information, see:
-        # https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb
-        client.middleware.insert(
-          -2,
-          Faraday::Request::Retry,
-          methods: [:get, :head, :options, :put, :patch, :delete],
-        )
-
-        client.middleware.insert_after(
-          Restforce::Middleware::InstanceURL,
-          FaradayMiddleware::Instrumentation,
-          name: "request.restforce_db",
-        )
-
-        client.middleware.insert_before(
-          FaradayMiddleware::Instrumentation,
-          Restforce::DB::Middleware::StoreRequestBody,
-        )
-
+        setup_middleware(client)
         client
       end
+    end
+
+    # Internal: Sets up the Restforce client's middleware handlers.
+    #
+    # Returns nothing.
+    def self.setup_middleware(client)
+      # NOTE: By default, the Retry middleware will catch timeout exceptions,
+      # and retry up to two times. For more information, see:
+      # https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb
+      client.middleware.insert(
+        -2,
+        Faraday::Request::Retry,
+        methods: [:get, :head, :options, :put, :patch, :delete],
+      )
+
+      client.middleware.insert_after(
+        Restforce::Middleware::InstanceURL,
+        FaradayMiddleware::Instrumentation,
+        name: "request.restforce_db",
+      )
+
+      client.middleware.insert_before(
+        FaradayMiddleware::Instrumentation,
+        Restforce::DB::Middleware::StoreRequestBody,
+      )
     end
 
     # Public: Get the ID of the Salesforce user which is being used to access

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -106,6 +106,12 @@ module Restforce
           methods: [:get, :head, :options, :put, :patch, :delete],
         )
 
+        client.middleware.insert_after(
+          Restforce::Middleware::InstanceURL,
+          FaradayMiddleware::Instrumentation,
+          name: 'request.restforce_db',
+        )
+
         client
       end
     end

--- a/lib/restforce/db/middleware/store_request_body.rb
+++ b/lib/restforce/db/middleware/store_request_body.rb
@@ -1,0 +1,31 @@
+module Restforce
+
+  module DB
+
+    module Middleware
+
+      # Public: A Faraday middleware to store the request body in the environment.
+      #
+      # This works around an issue with Faraday where the request body is squashed by
+      # the response body, once a request has been made.
+      #
+      # See also:
+      # - https://github.com/lostisland/faraday/issues/163
+      # - https://github.com/lostisland/faraday/issues/297
+      class StoreRequestBody < Faraday::Middleware
+
+        # Public: Executes this middleware.
+        #
+        # request_env - The request's Env from Faraday.
+        def call(request_env)
+          request_env[:request_body] = request_env[:body]
+          @app.call(request_env)
+        end
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This change allows users of restforce-db to be notified (via [Active Support Notifications](http://guides.rubyonrails.org/active_support_instrumentation.html)) of API interactions.