### PR TITLE
Traverse Salesforce associations in attribute map

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -19,6 +19,9 @@ require "restforce/db/associations/foreign_key"
 require "restforce/db/associations/has_many"
 require "restforce/db/associations/has_one"
 
+require "restforce/db/attribute_maps/database"
+require "restforce/db/attribute_maps/salesforce"
+
 require "restforce/db/field_processor"
 require "restforce/db/instances/base"
 require "restforce/db/instances/active_record"

--- a/lib/restforce/db/attribute_maps/database.rb
+++ b/lib/restforce/db/attribute_maps/database.rb
@@ -1,0 +1,73 @@
+module Restforce
+
+  module DB
+
+    module AttributeMaps
+
+      # Restforce::DB::AttributeMaps::Database encapsulates the logic for
+      # compiling and parsing normalized attribute hashes from/for ActiveRecord
+      # objects.
+      class Database
+
+        # Public: Initialize a Restforce::DB::AttributeMaps::Database.
+        #
+        # fields  - A Hash of mappings between database columns and fields in
+        #           Salesforce.
+        # adapter - An adapter object which should be used to convert between
+        #           data formats.
+        def initialize(fields, adapter = Adapter.new)
+          @fields = fields
+          @adapter = adapter
+        end
+
+        # Public: Build a normalized Hash of attributes from the appropriate set
+        # of mappings. The keys of the resulting mapping Hash will correspond to
+        # the Salesforce field names.
+        #
+        # record - The underlying ActiveRecord object for which attributes
+        #          should be collected.
+        #
+        # Returns a Hash.
+        def attributes(record)
+          attributes = @fields.keys.each_with_object({}) do |attribute, values|
+            values[attribute] = record.send(attribute)
+          end
+          attributes = @adapter.from_database(attributes)
+
+          @fields.each_with_object({}) do |(attribute, mapping), final|
+            final[mapping] = attributes[attribute]
+          end
+        end
+
+        # Public: Convert a Hash of normalized attributes to a format suitable
+        # for consumption by an ActiveRecord object.
+        #
+        # attributes - A Hash of attributes, with keys corresponding to the
+        #              normalized Salesforce attribute names.
+        #
+        # Examples
+        #
+        #   attribute_map = AttributeMaps::Database.new(
+        #     some_key: "SomeField__c",
+        #   )
+        #
+        #   attribute_map.convert(MyClass, "Some_Field__c" => "some value")
+        #   # => { some_key: "some value" }
+        #
+        # Returns a Hash.
+        def convert(attributes)
+          attributes = @fields.each_with_object({}) do |(attribute, mapping), converted|
+            next unless attributes.key?(mapping)
+            converted[attribute] = attributes[mapping]
+          end
+
+          @adapter.to_database(attributes)
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/attribute_maps/salesforce.rb
+++ b/lib/restforce/db/attribute_maps/salesforce.rb
@@ -1,0 +1,62 @@
+module Restforce
+
+  module DB
+
+    module AttributeMaps
+
+      # Restforce::DB::AttributeMaps::Database encapsulates the logic for
+      # compiling and parsing normalized attribute hashes from/for Salesforce
+      # objects.
+      class Salesforce
+
+        # Public: Initialize a Restforce::DB::AttributeMaps::Salesforce.
+        #
+        # fields - A Hash of mappings between database columns and fields in
+        #          Salesforce.
+        def initialize(fields)
+          @fields = fields
+        end
+
+        # Public: Build a normalized Hash of attributes from the appropriate set
+        # of mappings. The keys of the resulting mapping Hash will correspond to
+        # the Salesforce field names.
+        #
+        # record - The underlying Salesforce object for which attributes should
+        #          be collected.
+        #
+        # Returns a Hash.
+        def attributes(record)
+          @fields.values.each_with_object({}) do |mapping, values|
+            values[mapping] = mapping.split(".").inject(record) do |value, portion|
+              value[portion]
+            end
+          end
+        end
+
+        # Public: Convert a Hash of normalized attributes to a format suitable
+        # for consumption by an ActiveRecord object.
+        #
+        # attributes - A Hash of attributes, with keys corresponding to the
+        #              normalized Salesforce attribute names.
+        #
+        # Examples
+        #
+        #   attribute_map = AttributeMaps::Salesforce.new(
+        #     some_key: "SomeField__c",
+        #   )
+        #
+        #   mapping.convert("Object__c", "Some_Field__c" => "some other value")
+        #   # => { "Some_Field__c" => "some other value" }
+        #
+        # Returns a Hash.
+        def convert(attributes)
+          attributes.dup
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/instances/base.rb
+++ b/lib/restforce/db/instances/base.rb
@@ -37,7 +37,7 @@ module Restforce
         #
         # Returns a Hash.
         def attributes
-          @mapping.attributes(@record_type) { |attribute| record.send(attribute) }
+          @mapping.attributes(@record_type, record)
         end
 
         # Public: Has this record been synced with Salesforce?

--- a/test/lib/restforce/db/attribute_map_test.rb
+++ b/test/lib/restforce/db/attribute_map_test.rb
@@ -23,23 +23,19 @@ describe Restforce::DB::AttributeMap do
     end
 
     it "builds a normalized Hash of database attribute values" do
-      attributes = attribute_map.attributes(database_model) do |attribute|
-        expect(mapping.database_fields.include?(attribute)).to_equal true
-        attribute
-      end
+      record = Hashie::Mash.new(column_one: "Eenie", column_two: "Meenie")
+      attributes = attribute_map.attributes(database_model, record)
 
       expect(attributes.keys).to_equal(mapping.salesforce_fields)
-      expect(attributes.values).to_equal(mapping.database_fields)
+      expect(attributes.values).to_equal(%w(Eenie Meenie))
     end
 
     it "builds a normalized Hash of Salesforce field values" do
-      attributes = attribute_map.attributes(salesforce_model) do |attribute|
-        expect(mapping.salesforce_fields.include?(attribute)).to_equal true
-        attribute
-      end
+      record = Hashie::Mash.new("SF_Field_One__c" => "Minie", "SF_Field_Two__c" => "Moe")
+      attributes = attribute_map.attributes(salesforce_model, record)
 
       expect(attributes.keys).to_equal(mapping.salesforce_fields)
-      expect(attributes.values).to_equal(mapping.salesforce_fields)
+      expect(attributes.values).to_equal(%w(Minie Moe))
     end
   end
 
@@ -54,19 +50,6 @@ describe Restforce::DB::AttributeMap do
       expect(attribute_map.convert(database_model, attributes)).to_equal(
         fields.key(attributes.keys.first) => attributes.values.first,
       )
-    end
-
-    describe "when an adapter has been specified" do
-      let(:adapter) { boolean_adapter }
-
-      it "uses the adapter to convert attributes to a database-compatible form" do
-        expect(attribute_map.convert(database_model, "SF_Field_One__c" => "Yes")).to_equal(
-          column_one: true,
-        )
-        expect(attribute_map.convert(database_model, "SF_Field_One__c" => "No")).to_equal(
-          column_one: false,
-        )
-      end
     end
   end
 

--- a/test/lib/restforce/db/attribute_maps/database_test.rb
+++ b/test/lib/restforce/db/attribute_maps/database_test.rb
@@ -1,0 +1,51 @@
+require_relative "../../../../test_helper"
+
+describe Restforce::DB::AttributeMaps::Database do
+
+  configure!
+
+  let(:adapter) { Restforce::DB::Adapter.new }
+  let(:attribute_map) { Restforce::DB::AttributeMaps::Database.new(fields, adapter) }
+  let(:fields) do
+    {
+      column_one: "SF_Field_One__c",
+      column_two: "SF_Field_Two__c",
+    }
+  end
+
+  describe "#attributes" do
+
+    it "builds a normalized Hash of database attribute values" do
+      record = Hashie::Mash.new(column_one: "Winkin", column_two: "Blinkin")
+      attributes = attribute_map.attributes(record)
+
+      expect(attributes.keys).to_equal(fields.values)
+      expect(attributes.values).to_equal(%w(Winkin Blinkin))
+    end
+  end
+
+  describe "#convert" do
+    let(:attributes) { { "SF_Field_One__c" => "some value" } }
+
+    it "converts an attribute Hash to a database-compatible form" do
+      expect(attribute_map.convert(attributes)).to_equal(
+        fields.key(attributes.keys.first) => attributes.values.first,
+      )
+    end
+
+    describe "when an adapter has been specified" do
+      let(:adapter) { boolean_adapter }
+
+      it "uses the adapter to convert attributes to a database-compatible form" do
+        expect(attribute_map.convert("SF_Field_One__c" => "Yes")).to_equal(
+          column_one: true,
+        )
+        expect(attribute_map.convert("SF_Field_One__c" => "No")).to_equal(
+          column_one: false,
+        )
+      end
+
+    end
+  end
+
+end

--- a/test/lib/restforce/db/attribute_maps/salesforce_test.rb
+++ b/test/lib/restforce/db/attribute_maps/salesforce_test.rb
@@ -1,0 +1,54 @@
+require_relative "../../../../test_helper"
+
+describe Restforce::DB::AttributeMaps::Salesforce do
+
+  configure!
+
+  let(:attribute_map) { Restforce::DB::AttributeMaps::Salesforce.new(fields) }
+  let(:fields) do
+    {
+      column_one: "SF_Field_One__c",
+      column_two: "SF_Field_Two__c",
+    }
+  end
+
+  describe "#attributes" do
+
+    it "builds a normalized Hash of Salesforce attribute values" do
+      record = Hashie::Mash.new("SF_Field_One__c" => "Winkin", "SF_Field_Two__c" => "Blinkin")
+      attributes = attribute_map.attributes(record)
+
+      expect(attributes.keys).to_equal(fields.values)
+      expect(attributes.values).to_equal(%w(Winkin Blinkin))
+    end
+
+    describe "for a mapping requiring Salesforce association traversal" do
+      let(:fields) do
+        {
+          name: "Name",
+          friend_name: "Friend__r.Name",
+        }
+      end
+
+      it "builds a flattened normalized Hash of Salesforce attribute values" do
+        record = Hashie::Mash.new(
+          "Name" => "Turner",
+          "Friend__r" => { "Name" => "Hooch" },
+        )
+        attributes = attribute_map.attributes(record)
+
+        expect(attributes.keys).to_equal(fields.values)
+        expect(attributes.values).to_equal(%w(Turner Hooch))
+      end
+    end
+  end
+
+  describe "#convert" do
+    let(:attributes) { { "SF_Field_One__c" => "some value" } }
+
+    it "doesn't perform any special modification of the passed attribute Hash" do
+      expect(attribute_map.convert(attributes)).to_equal(attributes)
+    end
+  end
+
+end


### PR DESCRIPTION
Currently, there’s no way to assign a (read-only) value from an 
associated Salesforce record to your database record on sync, which
means that pulling down one-off fields potentially requires a lot of
unwanted black magic in your mappings.

To make things a bit more straightforward, we can traverse associations
when building out our normalized attribute hashes, consolidating the 
nested hashes constructed by Restforce::DB into flat one-to-one maps 
using the dot-separated attribute name.