### PR TITLE
Refactor Worker to run sync within subprocesses

### DIFF
--- a/lib/file_daemon.rb
+++ b/lib/file_daemon.rb
@@ -15,6 +15,15 @@ module FileDaemon
   # :nodoc:
   module ClassMethods
 
+    # Public: Force-reopen all files at their current paths. Allows for rotation
+    # of log files outside of the context of an actual process fork.
+    #
+    # Returns nothing.
+    def reopen_files
+      before_fork
+      after_fork
+    end
+
     # Public: Store the list of currently open file descriptors so that they
     # may be reopened when a new process is spawned.
     #

--- a/lib/file_daemon.rb
+++ b/lib/file_daemon.rb
@@ -20,7 +20,7 @@ module FileDaemon
     #
     # Returns nothing.
     def before_fork
-      @files_to_reopen ||= ObjectSpace.each_object(File).reject(&:closed?)
+      @files_to_reopen = ObjectSpace.each_object(File).reject(&:closed?)
     end
 
     # Public: Reopen all file descriptors that have been stored through the

--- a/lib/forked_process.rb
+++ b/lib/forked_process.rb
@@ -1,0 +1,45 @@
+require "English"
+
+# ForkedProcess exposes a small API for performing a block of code in a
+# forked process, and relaying its output to another block.
+class ForkedProcess
+
+  # Public: Define a callback which will be run in a forked process.
+  #
+  # Yields an IO object opened for writing when `run` is invoked.
+  # Returns nothing.
+  def write(&block)
+    @write_block = block
+  end
+
+  # Public: Define a callback which reads in the output from the forked
+  # process.
+  #
+  # Yields an IO object opened for reading when `run` is invoked.
+  # Returns nothing.
+  def read(&block)
+    @read_block = block
+  end
+
+  # Public: Fork a process, opening a pipe for IO and yielding the write and
+  # read components to the relevant blocks.
+  #
+  # Returns nothing.
+  def run
+    reader, writer = IO.pipe
+
+    pid = fork do
+      reader.close
+      @write_block.call(writer)
+      writer.close
+      exit!(0)
+    end
+
+    writer.close
+    @read_block.call(reader)
+    Process.wait(pid)
+
+    raise "Forked process did not exit successfully" unless $CHILD_STATUS.success?
+  end
+
+end

--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -39,18 +39,10 @@ require "restforce/db/record_cache"
 require "restforce/db/timestamp_cache"
 require "restforce/db/runner"
 
-require "restforce/db/task"
-require "restforce/db/accumulator"
-require "restforce/db/attacher"
 require "restforce/db/adapter"
-require "restforce/db/associator"
 require "restforce/db/attribute_map"
-require "restforce/db/cleaner"
-require "restforce/db/collector"
-require "restforce/db/initializer"
 require "restforce/db/mapping"
 require "restforce/db/model"
-require "restforce/db/synchronizer"
 require "restforce/db/tracker"
 require "restforce/db/worker"
 
@@ -89,7 +81,7 @@ module Restforce
     # Returns a Restforce::Data::Client instance.
     def self.client
       @client ||= begin
-        client = DB::Client.new(
+        DB::Client.new(
           username:       configuration.username,
           password:       configuration.password,
           security_token: configuration.security_token,
@@ -100,34 +92,7 @@ module Restforce
           timeout:        configuration.timeout,
           adapter:        configuration.adapter,
         )
-        setup_middleware(client)
-        client
       end
-    end
-
-    # Internal: Sets up the Restforce client's middleware handlers.
-    #
-    # Returns nothing.
-    def self.setup_middleware(client)
-      # NOTE: By default, the Retry middleware will catch timeout exceptions,
-      # and retry up to two times. For more information, see:
-      # https://github.com/lostisland/faraday/blob/master/lib/faraday/request/retry.rb
-      client.middleware.insert(
-        -2,
-        Faraday::Request::Retry,
-        methods: [:get, :head, :options, :put, :patch, :delete],
-      )
-
-      client.middleware.insert_after(
-        Restforce::Middleware::InstanceURL,
-        FaradayMiddleware::Instrumentation,
-        name: "request.restforce_db",
-      )
-
-      client.middleware.insert_before(
-        FaradayMiddleware::Instrumentation,
-        Restforce::DB::Middleware::StoreRequestBody,
-      )
     end
 
     # Public: Get the ID of the Salesforce user which is being used to access

--- a/lib/restforce/db/command.rb
+++ b/lib/restforce/db/command.rb
@@ -15,7 +15,6 @@ module Restforce
       # args - A set of command line arguments to pass to the OptionParser.
       def initialize(args)
         @options = {
-          verbose: false,
           pid_dir: Rails.root.join("tmp", "pids"),
           config:  Rails.root.join("config", "restforce-db.yml"),
           tracker: Rails.root.join("config", ".restforce"),
@@ -103,9 +102,6 @@ module Restforce
           end
           opt.on("-t FILE", "--tracker FILE", "The file where run characteristics should be logged.") do |file|
             @options[:tracker] = file
-          end
-          opt.on("-v", "--verbose", "Turn on noisy logging.") do
-            @options[:verbose] = true
           end
         end
       end

--- a/lib/restforce/db/loggable.rb
+++ b/lib/restforce/db/loggable.rb
@@ -1,0 +1,43 @@
+module Restforce
+
+  module DB
+
+    # Restforce::DB::Loggable defines shared behaviors for objects which
+    # need access to generic logging functionality.
+    module Loggable
+
+      # Public: Add a `logger` attribute to the object including this module.
+      #
+      # base - The object which is including the `Loggable` module.
+      def self.included(base)
+        base.send :attr_accessor, :logger
+      end
+
+      private
+
+      # Internal: Log the passed text at the specified level.
+      #
+      # text  - The piece of text which should be logged for this worker.
+      # level - The level at which the text should be logged. Defaults to :info.
+      #
+      # Returns nothing.
+      def log(text, level = :info)
+        return unless logger
+        logger.send(level, text)
+      end
+
+      # Internal: Log an error for the worker, outputting the entire error
+      # stacktrace and applying the appropriate log level.
+      #
+      # exception - An Exception object.
+      #
+      # Returns nothing.
+      def error(exception)
+        log exception, :error
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -15,6 +15,8 @@ module Restforce
         :@timestamp_cache,
         :cache_timestamp,
         :changed?,
+        :dump_timestamps,
+        :load_timestamps,
       )
 
       # Public: Initialize a new Restforce::DB::Runner.

--- a/lib/restforce/db/task_manager.rb
+++ b/lib/restforce/db/task_manager.rb
@@ -1,0 +1,96 @@
+require "restforce/db/loggable"
+require "restforce/db/task"
+require "restforce/db/accumulator"
+require "restforce/db/attacher"
+require "restforce/db/associator"
+require "restforce/db/cleaner"
+require "restforce/db/collector"
+require "restforce/db/initializer"
+require "restforce/db/synchronizer"
+
+module Restforce
+
+  # :nodoc:
+  module DB
+
+    # TaskMapping is a small data structure used to pass top-level task
+    # information through to a SynchronizationError when necessary.
+    TaskMapping = Struct.new(:id, :mapping)
+
+    # Restforce::DB::TaskManager defines the run sequence and invocation of each
+    # of the Restforce::DB::Task subclasses during a single processing loop for
+    # the top-level Worker object.
+    class TaskManager
+
+      include Loggable
+
+      # Public: Initialize a new Restforce::DB::TaskManager for a given runner
+      # state.
+      #
+      # runner - A Restforce::DB::Runner for a specific period of time.
+      # logger - A Logger object (optional).
+      def initialize(runner, logger: nil)
+        @runner = runner
+        @logger = logger
+        @changes = Hash.new { |h, k| h[k] = Accumulator.new }
+      end
+
+      # Public: Run each of the sync tasks in a defined order for the supplied
+      # runner's current state.
+      #
+      # Returns nothing.
+      def perform
+        Registry.each do |mapping|
+          run("CLEANING RECORDS", Cleaner, mapping)
+          run("ATTACHING RECORDS", Attacher, mapping)
+          run("PROPAGATING RECORDS", Initializer, mapping)
+          run("COLLECTING CHANGES", Collector, mapping)
+        end
+
+        # NOTE: We can only perform the synchronization after all record changes
+        # have been aggregated, so this second loop is necessary.
+        Registry.each do |mapping|
+          run("UPDATING ASSOCIATIONS", Associator, mapping)
+          run("APPLYING CHANGES", Synchronizer, mapping)
+        end
+      end
+
+      private
+
+      # Internal: Log a description and response time for a specific named task.
+      #
+      # name       - A String task name.
+      # task_class - A Restforce::DB::Task subclass.
+      # mapping    - A Restforce::DB::Mapping.
+      #
+      # Returns a Boolean.
+      def run(name, task_class, mapping)
+        log "  #{name} between #{mapping.database_model.name} and #{mapping.salesforce_model}"
+        runtime = Benchmark.realtime { task task_class, mapping }
+        log format("  FINISHED #{name} after %.4f", runtime)
+
+        true
+      rescue => e
+        error(e)
+
+        false
+      end
+
+      # Internal: Run the passed mapping through the supplied Task class.
+      #
+      # task_class - A Restforce::DB::Task subclass.
+      # mapping    - A Restforce::DB::Mapping.
+      #
+      # Returns nothing.
+      def task(task_class, mapping)
+        task_class.new(mapping, @runner).run(@changes)
+      rescue Faraday::Error::ClientError => e
+        task_mapping = TaskMapping.new(task_class, mapping)
+        error SynchronizationError.new(e, task_mapping)
+      end
+
+    end
+
+  end
+
+end

--- a/lib/restforce/db/timestamp_cache.rb
+++ b/lib/restforce/db/timestamp_cache.rb
@@ -71,6 +71,26 @@ module Restforce
         @cache = {}
       end
 
+      # Public: Load the previous collection of cached timestamps from the
+      # passed readable object.
+      #
+      # io - An IO object opened for reading.
+      #
+      # Returns nothing.
+      def load_timestamps(io)
+        @cache = YAML.load(io.read) || {}
+      end
+
+      # Public: Dump the currently cached timestamps into the specified
+      # writable object.
+      #
+      # io - An IO object opened for writing.
+      #
+      # Returns nothing.
+      def dump_timestamps(io)
+        io.write(YAML.dump(@cache))
+      end
+
       private
 
       # Internal: Get a unique cache key for the passed instance.

--- a/test/lib/restforce/db/timestamp_cache_test.rb
+++ b/test/lib/restforce/db/timestamp_cache_test.rb
@@ -84,4 +84,34 @@ describe Restforce::DB::TimestampCache do
     end
   end
 
+  describe "I/O operations" do
+    let(:io) { IO.pipe }
+    let(:reader) { io.first }
+    let(:writer) { io.last }
+
+    describe "#dump_timestamps" do
+      before do
+        cache.cache_timestamp instance
+        cache.dump_timestamps(writer)
+        writer.close
+      end
+
+      it "writes a YAML dump of the cache to the passed I/O object" do
+        expect(YAML.load(reader.read)).to_equal [record_type, id] => timestamp
+      end
+    end
+
+    describe "#load_timestamps" do
+      before do
+        YAML.dump({ [record_type, id] => timestamp }, writer)
+        writer.close
+        cache.load_timestamps(reader)
+      end
+
+      it "reloads its internal cache from the passed I/O object" do
+        expect(cache.timestamp(instance)).to_equal timestamp
+      end
+    end
+  end
+
 end

--- a/test/lib/restforce/db/worker_test.rb
+++ b/test/lib/restforce/db/worker_test.rb
@@ -20,7 +20,8 @@ describe Restforce::DB::Worker do
 
       ## 1b. The record is synced to Salesforce.
       worker.send :reset!
-      worker.send :task, Restforce::DB::Initializer, mapping
+      manager = worker.send(:task_manager)
+      manager.send :task, Restforce::DB::Initializer, mapping
 
       expect(database_record.reload).to_be :salesforce_id?
       Salesforce.records << [salesforce_model, database_record.salesforce_id]
@@ -44,8 +45,9 @@ describe Restforce::DB::Worker do
         # We sleep here to ensure we pick up our manual changes.
         sleep 1 if VCR.current_cassette.recording?
         worker.send :reset!
-        worker.send :task, Restforce::DB::Collector, mapping
-        worker.send :task, Restforce::DB::Synchronizer, mapping
+        manager = worker.send(:task_manager)
+        manager.send :task, Restforce::DB::Collector, mapping
+        manager.send :task, Restforce::DB::Synchronizer, mapping
       end
     end
 


### PR DESCRIPTION
In an effort to make the long-lived sync process more tenable, we need
to ensure that Ruby’s tendency to consume large amounts of memory (then
never free it back up) is mitigated.

To this end, we can ensure that memory temporarily consumed during the
sync is freed back up by performing all of our sync tasks within a
subprocess. When the process exits: free garbage collection.

In order to get this working, we also needed to invoke the appropriate
before/after hooks for file reopening, which, as a side effect, made it
trivial to implement handling of the `HUP`/`USR1` signals for log rotation.

To support this strategy, we've implemented a `ForkedProcess` pattern, 
which allows for bits of information to be passed between a forked
process and its parent. We use this to keep the master timestamp cache
up-to-date, as well as to preload the Salesforce field metadata on Worker
spinup.
