### PR TITLE
Avoid caching records on aggregate Cleaner queries

### DIFF
--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -113,7 +113,7 @@ module Restforce
       #
       # Returns an Array of IDs.
       def all_salesforce_ids
-        @mapping.unscoped { salesforce_ids(@mapping) }
+        @mapping.unscoped { salesforce_ids(@mapping, false) }
       end
 
       # Internal: Get the IDs of the recently-modified Salesforce records for
@@ -128,11 +128,13 @@ module Restforce
       # meet the conditions for this mapping.
       #
       # mapping - A Restforce::DB::Mapping.
+      # cached  - A Boolean reflecting whether or not the collection should
+      #           be cached.
       #
       # Returns an Array of IDs.
-      def salesforce_ids(mapping)
+      def salesforce_ids(mapping, cached = true)
         @runner.run(mapping) do |run|
-          run.salesforce_instances.map(&:id)
+          run.salesforce_instances(cached).map(&:id)
         end
       end
 

--- a/lib/restforce/db/runner.rb
+++ b/lib/restforce/db/runner.rb
@@ -64,17 +64,31 @@ module Restforce
       # Public: Iterate through recently-updated records for the Salesforce
       # record type defined by the current mapping.
       #
+      # cached - A Boolean reflecting whether or not the collection should be
+      #          fetched through this runner's RecordCache.
+      #
       # Returns an Enumerator yielding Restforce::DB::Instances::Salesforces.
-      def salesforce_instances
-        @record_cache.collection(@mapping, :salesforce_record_type, options)
+      def salesforce_instances(cached = true)
+        if cached
+          @record_cache.collection(@mapping, :salesforce_record_type, options)
+        else
+          @mapping.salesforce_record_type.all(options)
+        end
       end
 
       # Public: Iterate through recently-updated records for the database model
       # record type defined by the current mapping.
       #
+      # cached - A Boolean reflecting whether or not the collection should be
+      #          fetched through this runner's RecordCache.
+      #
       # Returns an Enumerator yielding Restforce::DB::Instances::ActiveRecords.
-      def database_instances
-        @record_cache.collection(@mapping, :database_record_type, options)
+      def database_instances(cached = true)
+        if cached
+          @record_cache.collection(@mapping, :database_record_type, options)
+        else
+          @mapping.database_record_type.all(options)
+        end
       end
 
       private


### PR DESCRIPTION
In the event of a massive Salesforce update for a particular mapping, 
caching the results of our `all_salesforce_ids` query doesn’t really
accomplish anything other than chewing through memory.