### PR TITLE
Handle bad Faraday responses with Restforce::AuthenticationError bubbling

### DIFF
--- a/lib/forked_process.rb
+++ b/lib/forked_process.rb
@@ -4,6 +4,8 @@ require "English"
 # forked process, and relaying its output to another block.
 class ForkedProcess
 
+  class UnsuccessfulExit < RuntimeError; end
+
   # Public: Define a callback which will be run in a forked process.
   #
   # Yields an IO object opened for writing when `run` is invoked.
@@ -39,7 +41,7 @@ class ForkedProcess
     @read_block.call(reader)
     Process.wait(pid)
 
-    raise "Forked process did not exit successfully" unless $CHILD_STATUS.success?
+    raise UnsuccessfulExit unless $CHILD_STATUS.success?
   end
 
 end

--- a/lib/restforce/db/task_manager.rb
+++ b/lib/restforce/db/task_manager.rb
@@ -59,6 +59,11 @@ module Restforce
 
       # Internal: Log a description and response time for a specific named task.
       #
+      # NOTE: AuthenticationErrors from Restforce's middleware seem to be linked
+      # to thread-safety issues, so we want to error out the entire processing
+      # loop in the event that we run into one of these. This is the reason for
+      # the fairly convoluted `rescue` chain below.
+      #
       # name       - A String task name.
       # task_class - A Restforce::DB::Task subclass.
       # mapping    - A Restforce::DB::Mapping.
@@ -70,6 +75,9 @@ module Restforce
         log format("  FINISHED #{name} after %.4f", runtime)
 
         true
+      rescue Restforce::AuthenticationError => e
+        error(e)
+        raise e
       rescue => e
         error(e)
         false

--- a/lib/restforce/db/worker.rb
+++ b/lib/restforce/db/worker.rb
@@ -127,10 +127,11 @@ module Restforce
 
           begin
             forked.run
-          rescue => e
+          rescue ForkedProcess::UnsuccessfulExit => e
             # NOTE: Due to thread-safety issues in any of a number of libraries
-            # included in the host application (even ActiveSupport itself), our
-            # forked processes may occasionally encounter LoadErrors.
+            # included in the host application (even in ActiveSupport itself),
+            # our forked processes may occasionally encounter various annoying
+            # and intermittent errors.
             #
             # Retrying here is our way of handling that. It's not great, but
             # it's the best we can do for now without sacrificing the benefits

--- a/lib/restforce/extensions.rb
+++ b/lib/restforce/extensions.rb
@@ -1,6 +1,24 @@
 module Restforce
 
   # :nodoc:
+  class Middleware::Authentication < Restforce::Middleware # rubocop:disable Style/ClassAndModuleChildren
+
+    # Internal: Get an error message for the passed response. Overrides the
+    # default behavior of the middleware to correctly handle broken responses
+    # from Faraday.
+    #
+    # Returns a String.
+    def error_message(response)
+      if response.status == 0
+        "Request was closed prematurely"
+      else
+        "#{response.body['error']}: #{response.body['error_description']}"
+      end
+    end
+
+  end
+
+  # :nodoc:
   class SObject
 
     # Public: Update the Salesforce record with the passed attributes.

--- a/test/lib/forked_process_test.rb
+++ b/test/lib/forked_process_test.rb
@@ -1,0 +1,39 @@
+require_relative "../test_helper"
+
+describe ForkedProcess do
+
+  describe "running a forked process" do
+    let(:process) do
+      ForkedProcess.new.tap do |forked|
+        forked.write { |writer| writer.write("Hello!") }
+      end
+    end
+
+    describe "#run" do
+
+      it "synchronizes the `write` block's output into a `read` block" do
+        value = nil
+
+        process.read { |reader| value = reader.read }
+        process.run
+
+        expect(value).to_equal("Hello!")
+      end
+
+      describe "when the write block exits unsuccessfully due to an error" do
+        let(:process) do
+          ForkedProcess.new.tap do |forked|
+            forked.write { |_| raise "Whoops!" }
+            forked.read { |_| nil }
+          end
+        end
+
+        it "raises an UnsuccessfulExit exception" do
+          expect { silence_stream(STDERR) { process.run } }.to_raise(
+            ForkedProcess::UnsuccessfulExit,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There’s an underlying “bug” in the Restforce library, which results in
an error when the response from Faraday doesn’t have a body for some
reason. It’s still unclear what the conditions leading to this edge case
are, but it seems tied to a number of other thread-safety issues, and
we should generally just take it as our cue to error out of the current
fork and try everything again.