### PR TITLE
Reduce logging level to :warn for auth errors

### DIFF
--- a/lib/restforce/db/task_manager.rb
+++ b/lib/restforce/db/task_manager.rb
@@ -76,7 +76,7 @@ module Restforce
 
         true
       rescue Restforce::AuthenticationError => e
-        error(e)
+        log e, :warn
         raise e
       rescue => e
         error(e)


### PR DESCRIPTION
The "Request was closed prematurely" exception is triggered fairly 
frequently during synchronization worker loops, and doesn’t seem to 
represent anything actionable. Since we handle it at the sync level by
retrying the entire processing loop, it should be sufficient to log the
exception at the :warn level and proceed as usual.