### PR TITLE
Extract SFID hashing functionality into method

### DIFF
--- a/lib/restforce/db.rb
+++ b/lib/restforce/db.rb
@@ -54,6 +54,10 @@ module Restforce
   # by the other classes in this library.
   module DB
 
+    # Internal: A String containing the valid suffix Hash values for a
+    # Salesforce ID.
+    HASH_DICTIONARY = "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345".freeze
+
     class << self
 
       attr_accessor :last_run
@@ -138,6 +142,28 @@ module Restforce
 
       @configuration = nil
       @last_run = nil
+    end
+
+    # Public: Get the hashed version of the passed salesforce ID. This will
+    # converts 15-digit Salesforce IDs to their corresponding 18-digit version.
+    # Returns any passed 18-digit IDs back, untouched.
+    #
+    # Returns a String.
+    # Raises an ArgumentError if the passed String is not 15 characters.
+    def self.hashed_id(salesforce_id)
+      return salesforce_id if salesforce_id.length == 18
+      raise ArgumentError, "The passed Salesforce ID must be 15 or 18 characters" unless salesforce_id.length == 15
+
+      suffixes = salesforce_id.scan(/.{5}/).map do |chunk|
+        flag = 0
+        chunk.split("").each_with_index do |char, idx|
+          flag += (1 << idx) if char >= "A" && char <= "Z"
+        end
+
+        HASH_DICTIONARY[flag]
+      end
+
+      salesforce_id + suffixes.join
     end
 
   end

--- a/lib/tasks/restforce.rake
+++ b/lib/tasks/restforce.rake
@@ -48,19 +48,8 @@ namespace :restforce do
   desc "Get the 18-character version of a 15-character Salesforce ID"
   task :convertid, [:salesforce_id] do |_, args|
     sfid = args[:salesforce_id]
-
     raise ArgumentError, "Provide a Salesforce ID (restforce:convertid[<salesforce_id>])" if sfid.nil?
-    raise ArgumentError, "The passed Salesforce ID must be 15 characters" unless sfid.length == 15
 
-    suffixes = sfid.scan(/.{5}/).map do |chunk|
-      flag = 0
-      chunk.split("").each_with_index do |char, idx|
-        flag += (1 << idx) if char.upcase == char && char >= "A" && char <= "Z"
-      end
-
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"[flag]
-    end
-
-    puts sfid + suffixes.join
+    puts Restforce::DB.hashed_id(sfid)
   end
 end

--- a/test/lib/restforce/db_test.rb
+++ b/test/lib/restforce/db_test.rb
@@ -4,7 +4,7 @@ describe Restforce::DB do
 
   configure!
 
-  describe "#configure" do
+  describe ".configure" do
 
     it "yields a Configuration" do
       Restforce::DB.configure do |config|
@@ -13,7 +13,7 @@ describe Restforce::DB do
     end
   end
 
-  describe "#client" do
+  describe ".client" do
     before do
       Restforce::DB.configure do |config|
         config.adapter = :net_http
@@ -25,6 +25,26 @@ describe Restforce::DB do
 
       expect(handlers[-2].klass).to_equal(Faraday::Request::Retry)
       expect(handlers[-1].klass).to_equal(Faraday::Adapter::NetHttp)
+    end
+  end
+
+  describe ".hashed_id" do
+
+    it "returns an 18-character Salesforce ID untouched" do
+      expect(Restforce::DB.hashed_id("a001a000002zhZfAAI")).to_equal("a001a000002zhZfAAI")
+    end
+
+    it "generates a proper hash for a 15-character Salesforce ID" do
+      expect(Restforce::DB.hashed_id("aaaaaaaaaaaaaaa")).to_equal("aaaaaaaaaaaaaaaAAA")
+      expect(Restforce::DB.hashed_id("AaaAAAaaAAAaaAA")).to_equal("AaaAAAaaAAAaaAAZZZ")
+      expect(Restforce::DB.hashed_id("aAaAAaAaAAaAaAA")).to_equal("aAaAAaAaAAaAaAA000")
+      expect(Restforce::DB.hashed_id("AAAAAAAAAAAAAAA")).to_equal("AAAAAAAAAAAAAAA555")
+
+      expect(Restforce::DB.hashed_id("0063200001kSU3I")).to_equal("0063200001kSU3IAAW")
+    end
+
+    it "raises an ArgumentError if the passed String contains an invalid character count" do
+      expect { Restforce::DB.hashed_id("a001a000002zhZfA") }.to_raise(ArgumentError)
     end
   end
 


### PR DESCRIPTION
It's often useful to be able to convert from a 15-character Salesforce ID (generally used by Salesforce to populate its URLs) to the 18-character hashed version of that ID (used for explicit access to records through the API). To make this functionality more accessible, we can expose it as a method on the top-level `Restforce::DB` module.