### PR TITLE
Clean up handling of deleted records query

### DIFF
--- a/lib/restforce/db/cleaner.rb
+++ b/lib/restforce/db/cleaner.rb
@@ -42,7 +42,7 @@ module Restforce
           @runner.before,
         )
 
-        response.deletedRecords.map(&:id)
+        response.map(&:id)
       end
 
       # Internal: Get the IDs of records which are in the larger collection

--- a/lib/restforce/db/client.rb
+++ b/lib/restforce/db/client.rb
@@ -59,7 +59,7 @@ module Restforce
       #          >,
       #       ]
       #
-      # Returns a Restforce::Mash with a `deletedRecords` key.
+      # Returns an Array of Restforce::Mash objects.
       def get_deleted_between(sobject, start_time, end_time = Time.now)
         response = api_get(
           "sobjects/#{sobject}/deleted",

--- a/lib/restforce/db/client.rb
+++ b/lib/restforce/db/client.rb
@@ -52,24 +52,22 @@ module Restforce
       #     Time.now,
       #   )
       #
-      #   #=> #<Restforce::Mash
-      #          latestDateCovered="2015-05-18T22:31:00.000+0000"
-      #          earliestDateAvailable="2015-04-11T06:44:00.000+0000"
-      #          deletedRecords=[
-      #            #<Restforce::Mash
-      #              deletedDate="2015-05-18T22:31:17.000+0000"
-      #              id="a001a000001a5vOAAQ"
-      #            >
-      #          ]
-      #        >
+      #   #=> [
+      #         #<Restforce::Mash
+      #           deletedDate="2015-05-18T22:31:17.000+0000"
+      #           id="a001a000001a5vOAAQ"
+      #          >,
+      #       ]
       #
       # Returns a Restforce::Mash with a `deletedRecords` key.
       def get_deleted_between(sobject, start_time, end_time = Time.now)
-        api_get(
+        response = api_get(
           "sobjects/#{sobject}/deleted",
           start: start_time.utc.iso8601,
           end: end_time.utc.iso8601,
-        ).body
+        )
+
+        Array(response.body["deletedRecords"])
       end
 
     end

--- a/test/lib/restforce/db/cleaner_test.rb
+++ b/test/lib/restforce/db/cleaner_test.rb
@@ -78,9 +78,9 @@ describe Restforce::DB::Cleaner do
         let(:runner) { Restforce::DB::Runner.new(0, Time.now - 300) }
         let(:cleaner) { Restforce::DB::Cleaner.new(mapping, runner) }
         let(:dummy_response) do
-          Struct.new(:deletedRecords).new([
+          [
             Restforce::Mash.new(id: salesforce_id),
-          ])
+          ]
         end
 
         before do


### PR DESCRIPTION
Frequently, the response body for this request is just an empty string.
In these events, we should treat the collection as an empty Array, and
avoid triggering an exception.